### PR TITLE
Adding TM link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ extra:
   social:
     - icon: cncf/cncf-icon-white
       link: https://www.cncf.io/
+    - icon: fontawesome/solid/trademark
+      link: https://www.linuxfoundation.org/trademark-usage/
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/orasproject
     - icon: fontawesome/brands/github


### PR DESCRIPTION
Adding Trademark link for the Linux Foundation, per the CNCFwebsite guidelines in https://github.com/cncf/foundation/blob/master/website-guidelines.md as part of onboarding in https://github.com/cncf/toc/issues/692.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>