### PR TITLE
Ensure auth metadata using port 5000

### DIFF
--- a/docs/implementors.md
+++ b/docs/implementors.md
@@ -51,7 +51,7 @@ This will start a distribution server at `localhost:5000`
   ```
   docker run -it --rm -p 5000:5000 \
       -v $(pwd)/auth.htpasswd:/etc/docker/registry/auth.htpasswd \
-      -e REGISTRY_AUTH="{htpasswd: {realm: localhost, path: /etc/docker/registry/auth.htpasswd}}" \
+      -e REGISTRY_AUTH="{htpasswd: {realm: localhost:5000, path: /etc/docker/registry/auth.htpasswd}}" \
       registry
   ```
 
@@ -94,7 +94,7 @@ To login to the registry without a certificate, a self-signed certificate, or an
   docker run -it --rm -p 5000:5000 \
       -v `pwd`/certs:/certs \
       -v $(pwd)/auth.htpasswd:/etc/docker/registry/auth.htpasswd \
-      -e REGISTRY_AUTH="{htpasswd: {realm: localhost, path: /etc/docker/registry/auth.htpasswd}}" \
+      -e REGISTRY_AUTH="{htpasswd: {realm: localhost:5000, path: /etc/docker/registry/auth.htpasswd}}" \
       -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 \
       -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
       -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
@@ -146,7 +146,7 @@ The `--plain-http` flag mean that you want to use http instead of https to conne
   ```
   docker run -it --rm -p 5000:5000 \
     -v $(pwd)/auth.htpasswd:/etc/docker/registry/auth.htpasswd \
-    -e REGISTRY_AUTH="{htpasswd: {realm: localhost, path: /etc/docker/registry/auth.htpasswd}}" \
+    -e REGISTRY_AUTH="{htpasswd: {realm: localhost:5000, path: /etc/docker/registry/auth.htpasswd}}" \
     -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 \
     registry
   ```


### PR DESCRIPTION
For the examples, setting the realm to just localhost means we get a header that has "realm" set to "localhost" when we actually need to it be "localhost:5000" for the authentication flow to work. I just got burned by this. :laughing: