### PR TITLE
removing PR trigger and adding direct push on documentation change

### DIFF
--- a/.github/workflows/oras-py-update.yaml
+++ b/.github/workflows/oras-py-update.yaml
@@ -3,9 +3,6 @@ on:
     # nightly at 5am
     - cron: '0 5 * * *'
 
-  repository_dispatch:
-    types: [oras-py-update]
-
 jobs:
   update-oras-py:
     runs-on: ubuntu-latest
@@ -16,50 +13,28 @@ jobs:
           git clone https://github.com/oras-project/oras-py /tmp/oras-py
           cp /tmp/oras-py/docs/1_python.md docs/Client_Libraries/1_python.md
 
-      - name: Checkout New Branch
+      - name: Push Updates
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           printf "GitHub Actor: ${GITHUB_ACTOR}\n"
-          export BRANCH_FROM="oras-py/update-$(date '+%Y-%m-%d')"
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-          BRANCH_EXISTS=$(git ls-remote --heads origin ${BRANCH_FROM})
-          if [[ -z ${BRANCH_EXISTS} ]]; then
-              printf "Branch does not exist in remote.\n"
-          else
-              printf "Branch already exists in remote.\n"
-              exit 1
-          fi
-          git branch
-          git checkout -b "${BRANCH_FROM}" || git checkout "${BRANCH_FROM}"
-          git fetch --unshallow origin
-          git branch
 
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@users.noreply.github.com"
+          git branch
+          git add docs/Client_Libraries/1_python.md
           git status
 
-          if git diff-index --quiet HEAD --; then
-             export OPEN_PULL_REQUEST=0
-             printf "No changes\n"
+          set +e
+          git status | grep modified
+          if [ $? -eq 0 ]; then
+              set -e
+              printf "Changes\n"
+              today=$(date '+%Y-%m-%d')
+              git commit -a -m "Automated deployment to update oras-py docs ${today}" -m "Signed-off-by: github-actions <github-actions@users.noreply.github.com>"  
+              git push origin main
           else
-             export OPEN_PULL_REQUEST=1
-             printf "Changes\n"
-             today=$(date '+%Y-%m-%d')
-             git add docs/Client_Libraries/1_python.md
-             git commit -a -m "Automated deployment to update oras-py docs ${today}" -m "Signed-off-by: github-actions <github-actions@users.noreply.github.com>"
-             git push origin "${BRANCH_FROM}"
+              set -e
+              printf "No changes\n"
           fi
-
-          echo "OPEN_PULL_REQUEST=${OPEN_PULL_REQUEST}" >> $GITHUB_ENV
-          echo "PULL_REQUEST_FROM_BRANCH=${BRANCH_FROM}" >> $GITHUB_ENV
-          echo "PULL_REQUEST_TITLE=[oras-py] ${BRANCH_FROM}" >> $GITHUB_ENV
-          echo "PULL_REQUEST_BODY=Oras-Py Documentation updates." >> $GITHUB_ENV
-
-      - name: Open Pull Request
-        uses: vsoch/pull-request-action@1.0.12
-        if: ${{ env.OPEN_PULL_REQUEST == '1' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_BRANCH: "main"


### PR DESCRIPTION
This PR will change the update to push directly instead of opening a PR, removing the need for human intervention. We can do this because the bot commits satisfy the DCO check.

I am also happy to review and merge changes from oras-py docs here manually (and if this is the preferred method please let me know and we will close this PR) but having a direct push means that we do not need that extra manual work. Note that I've also removed the repository dispatch (it won't be used) and changed the check from a comparison with HEAD to just looking for modified files (since we always will be on the main branch).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>