### PR TITLE
implementors.md: fix broken anchor link

### DIFF
--- a/docs/implementors.md
+++ b/docs/implementors.md
@@ -18,7 +18,7 @@ We're happy to promote all usage, as well as provide feedback.*
 - [Azure Container Registry](#azure-container-registry-acr)
 - [Amazon Elastic Container Registry](#amazon-elastic-container-registry-ecr)
 - [Google Artifact Registry](#google-artifact-registry-gar)
-- [GitHub Packages container registry](#github-container-registry)
+- [GitHub Packages container registry](#github-packages-container-registry-ghcr)
 - [Bundle Bar](#bundle-bar)
 
 ### CNCF Distribution


### PR DESCRIPTION
Clicking the anchor link to the github relevant section https://oras.land/implementors/ seems broken

![image](https://user-images.githubusercontent.com/5888506/180188561-39463a06-4a7e-42b3-b105-017e317e0a79.png)
