### PR TITLE
Update docs for breaking changes introduced in 0.14

### DIFF
--- a/docs/CLI/1_pushing.md
+++ b/docs/CLI/1_pushing.md
@@ -20,7 +20,7 @@ The following sample defines a new Artifact Type of **Acme Rocket**, using `appl
 
   ```
   oras push localhost:5000/hello-artifact:v1 \
-  --manifest-config /dev/null:application/vnd.acme.rocket.config \
+  --artifact-type application/vnd.acme.rocket.config \
   ./artifact.txt
   ```
 
@@ -36,7 +36,7 @@ The following sample defines a new Artifact Type of **Acme Rocket**, using `appl
 
   ```
   oras push localhost:5000/hello-artifact:v2 \
-  --manifest-config /dev/null:application/vnd.acme.rocket.config \
+  --artifact-type application/vnd.acme.rocket.config \
     artifact.txt:text/plain
   ```
 
@@ -54,7 +54,7 @@ The [OCI distribution-spec][distribution-spec] provides for storing optional con
 
   ```
   oras push localhost:5000/hello-artifact:v2 \
-  --manifest-config config.json:application/vnd.acme.rocket.config.v1+json \
+  --config config.json:application/vnd.acme.rocket.config.v1+json \
     artifact.txt:text/plain
   ```
 
@@ -86,7 +86,7 @@ See [OCI Artifacts][artifacts] for more details.
 
   ```
   oras push localhost:5000/hello-artifact:v2 \
-    --manifest-config config.json:application/vnd.acme.rocket.config.v1+json \
+    --config config.json:application/vnd.acme.rocket.config.v1+json \
     artifact.txt:text/plain \
     ./docs/:application/vnd.acme.rocket.docs.layer.v1+tar
   ```

--- a/docs/CLI/3_manifest_config.md
+++ b/docs/CLI/3_manifest_config.md
@@ -19,7 +19,7 @@ The descriptor of the default configuration object is fixed as follows.
 Users can customize the configuration object by the `--manifest-config file[:type]` option. To push a file `hi.txt` with the custom manifest config file `config.json`, run
 
 ```
-oras push --manifest-config config.json localhost:5000/hello:latest hi.txt
+oras push --config config.json localhost:5000/hello:latest hi.txt
 ```
 
 The media type of the config is set to the default value `application/vnd.unknown.config.v1+json`. 
@@ -27,13 +27,13 @@ The media type of the config is set to the default value `application/vnd.unknow
 Similar to the file reference, it is possible to change the media type of the manifest config. To push a file `hi.txt` with the custom manifest config file  `config.json` with the custom media type `application/vnd.oras.config.v1+json`, run
 
 ```
-oras push --manifest-config config.json:application/vnd.oras.config.v1+json localhost:5000/hello:latest hi.txt
+oras push --config config.json:application/vnd.oras.config.v1+json localhost:5000/hello:latest hi.txt
 ```
 
 In addition, it is possible to pass a null device `/dev/null` (`NUL` on Windows) to `oras` for an empty config file.
 
 ```
-oras push --manifest-config /dev/null:application/vnd.oras.config.v1+json localhost:5000/hello:latest hi.txt
+oras push --config /dev/null:application/vnd.oras.config.v1+json localhost:5000/hello:latest hi.txt
 ```
 
 ## Docker behaviors
@@ -60,7 +60,7 @@ unexpected end of JSON input
 ```
 $ cat config.json
 {}
-$ oras push --manifest-config config.json localhost:5000/hello:latest hi.txt
+$ oras push --config config.json localhost:5000/hello:latest hi.txt
 Uploading a948904f2f0f hi.txt
 Pushed localhost:5000/hello:latest
 Digest: sha256:44d13da4d42a20ceed7ee3411b103a6f82ef02a2eac981d5e3d799c41e3015d7
@@ -78,7 +78,7 @@ $ cat config.json
     "architecture": "cloud",
     "os": "oras"
 }
-$ oras push --manifest-config config.json localhost:5000/hello:latest hi.txt
+$ oras push --config config.json localhost:5000/hello:latest hi.txt
 Uploading a948904f2f0f hi.txt
 Pushed localhost:5000/hello:latest
 Digest: sha256:e6428c9cb88505a1859a01f4b7602bdb263d5f65399ef72d3397afd9bfb25b2c
@@ -91,7 +91,7 @@ operating system is not supported
 ### Arbitrary config media type
 
 ```
-$ oras push --manifest-config /dev/null:application/vnd.oras.config.v1+json localhost:5000/hello:latest hi.txt
+$ oras push --artifact-type application/vnd.oras.config.v1+json localhost:5000/hello:latest hi.txt
 Uploading a948904f2f0f hi.txt
 Pushed localhost:5000/hello:latest
 Digest: sha256:5d8ea018049870aab566350660b9a003c646a7f955f9996d35cc0c71bf41b3d0
@@ -119,7 +119,7 @@ $ cat annotations.json
         "org.opencontainers.image.title": "config.json"
     }
 }
-$ oras push --manifest-config config.json --manifest-annotations annotations.json localhost:5000/hello:latest hi.txt
+$ oras push --config config.json --manifest-annotations annotations.json localhost:5000/hello:latest hi.txt
 Uploading a948904f2f0f hi.txt
 Uploading 57f840b6073c config.json
 Pushed localhost:5000/hello:latest

--- a/docs/CLI/3_manifest_config.md
+++ b/docs/CLI/3_manifest_config.md
@@ -119,7 +119,7 @@ $ cat annotations.json
         "org.opencontainers.image.title": "config.json"
     }
 }
-$ oras push --config config.json --manifest-annotations annotations.json localhost:5000/hello:latest hi.txt
+$ oras push --config config.json --annotation-file annotations.json localhost:5000/hello:latest hi.txt
 Uploading a948904f2f0f hi.txt
 Uploading 57f840b6073c config.json
 Pushed localhost:5000/hello:latest

--- a/docs/CLI/4_manifest_annotations.md
+++ b/docs/CLI/4_manifest_annotations.md
@@ -7,7 +7,7 @@ are also supported by `oras`.
 
 ## Make annotations
 
-Users can make annotations to the manifest, the config, and individual files (i.e. layers) by the `--manifest-annotations file` option.
+Users can make annotations to the manifest, the config, and individual files (i.e. layers) by the `--annotation-file file` option.
 The annotations file is a JSON file with the following format:
 
 ```json
@@ -41,7 +41,7 @@ For instance, the following annotation file `annotations.json`:
 Running the following command
 
 ```
-oras push --manifest-annotations annotations.json localhost:5000/club:party cake.txt juice.txt
+oras push --annotation-file annotations.json localhost:5000/club:party cake.txt juice.txt
 ```
 
 results in

--- a/docs/Client_Libraries/1_python.md
+++ b/docs/Client_Libraries/1_python.md
@@ -121,7 +121,7 @@ Let's first push a container. Let's follow [the example here](https://oras.land/
 ```bash
 echo "hello dinosaur" > artifact.txt
 $ oras-py push localhost:5000/dinosaur/artifact:v1 \
---manifest-config /dev/null:application/vnd.acme.rocket.config \
+--artifact-type application/vnd.acme.rocket.config \
 ./artifact.txt
 Successfully pushed localhost:5000/dinosaur/artifact:v1
 ```
@@ -130,7 +130,7 @@ And if you aren't using https, add `--insecure`
 
 ```bash
 $ oras-py push localhost:5000/dinosaur/artifact:v1 --insecure \
---manifest-config /dev/null:application/vnd.acme.rocket.config \
+--artifact-type application/vnd.acme.rocket.config \
 ./artifact.txt
 Successfully pushed localhost:5000/dinosaur/artifact:v1
 ```

--- a/docs/implementors.md
+++ b/docs/implementors.md
@@ -195,7 +195,7 @@ ECR Artifact Blog Post: <https://aws.amazon.com/blogs/containers/oci-artifact-su
 
   ```
   oras push $REPO_URI:1.0 \
-      --manifest-config /dev/null:application/vnd.unknown.config.v1+json \
+      --artifact-type application/vnd.unknown.config.v1+json \
       ./artifact.txt:application/vnd.unknown.layer.v1+txt
   ```
 
@@ -226,7 +226,7 @@ ACR Artifact Documentation: [aka.ms/acr/artifacts](https://aka.ms/acr/artifacts)
 
   ```
   oras push myregistry.azurecr.io/samples/artifact:1.0 \
-      --manifest-config /dev/null:application/vnd.unknown.config.v1+json \
+      --artifact-type application/vnd.unknown.config.v1+json \
       ./artifact.txt:application/vnd.unknown.layer.v1+txt
   ```
 


### PR DESCRIPTION
As per the [0.14 release notes](https://github.com/oras-project/oras/releases/tag/v0.14.0), breaking changes around `--manifest-config` and `--manifest-annotations` were introduced. This PR updates the docs to reflect the changes made.

- `--manifest-config` was updated to `--config` wherever an actual manifest config was used. If using an empty manifest config file, `--artifact-type` is used instead.
- `--manifest-annotations` was updated to `--annotation-file`