### PR TITLE
Add workflow dispatch to update Python docs

### DIFF
--- a/.github/workflows/oras-py-update.yaml
+++ b/.github/workflows/oras-py-update.yaml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   schedule:
     # nightly at 5am
     - cron: '0 5 * * *'


### PR DESCRIPTION
In addition to the schedule, I'd like to be able to trigger an update of the workflow to update the Python docs so it can more closely coincide with library changes. The workflow dispatch event should allow for that.