### PR TITLE
fix: Remove reference to media-type option that was removed

### DIFF
--- a/docs/CLI/2_pulling.md
+++ b/docs/CLI/2_pulling.md
@@ -1,7 +1,6 @@
 # Pulling
 
 Pulling artifacts involves specifying the content addressable artifact, along with the type of artifact.
-> See: [Issue 130](https://github.com/oras-project/oras/issues/130) for eliminating `-a` and `--media-type`
 
 ```
 oras pull localhost:5000/hello-artifact:v2 -a


### PR DESCRIPTION
This issue has merged, no need to mention it.

Closes: https://github.com/oras-project/oras-www/issues/44

Signed-off-by: Terry Howe <tlhowe@amazon.com>