### PR TITLE
fix: revert missing redirects

### DIFF
--- a/docs/oras-go.md
+++ b/docs/oras-go.md
@@ -1,0 +1,5 @@
+---
+oras_go_meta: true
+---
+
+>Nothing to see here; <a href=https://github.com/oras-project/oras-go>move along</a>.

--- a/docs/oras-go/v2.md
+++ b/docs/oras-go/v2.md
@@ -1,0 +1,5 @@
+---
+oras_go_v2_meta: true
+---
+
+>Nothing to see here; <a href=https://github.com/oras-project/oras-go>move along</a>.

--- a/docs/oras.md
+++ b/docs/oras.md
@@ -1,0 +1,5 @@
+---
+oras_meta: true
+---
+
+Nothing to see here; <a href=https://github.com/oras-project/oras>move along</a>


### PR DESCRIPTION
It appears these redirects are used for installation. Causing on my `go mod tidy` to fail after clearing cache:

 `gotest.tools/v3/assert: oras.land/oras-go@v1.2.0: unrecognized import path "oras.land/oras-go": reading https://oras.land/oras-go?go-get=1: 404 Not Found`

Reverting these changes from https://github.com/oras-project/oras-www/pull/95
![Screen Shot 2023-02-08 at 13 29 43](https://user-images.githubusercontent.com/104113/217644127-fb9a47c5-7522-4735-bd84-0ea9e6b2b07d.png)

Signed-off-by: Terry Howe <tlhowe@amazon.com>