### PR TITLE
chore: add CODEOWNERS based on OWNERS.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Derived from OWNERS.md
+* @deitch
+* @FeynmanZhou
+* @jdolitsky
+* @sajayantony
+* @shizhMSFT
+* @stevelasker
+* @vsoch


### PR DESCRIPTION
Add [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) based on the [OWNERS.md](https://github.com/oras-project/oras-www/blob/main/OWNERS.md) file.