### PR TITLE
chore: update owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @deitch @FeynmanZhou @jdolitsky @sajayantony @shizhMSFT @stevelasker @vsoch
+* @FeynmanZhou @sajayantony @shizhMSFT @stevelasker @vsoch

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,10 +1,12 @@
 # Owners
 
 Owners:
-  - Avi Deitcher (@deitch)
   - Feynman Zhou (@FeynmanZhou)
-  - Josh Dolitsky (@jdolitsky)
   - Sajay Antony (@sajayantony)
   - Shiwei Zhang (@shizhMSFT)
   - Steve Lasker (@stevelasker)
   - Vanessasaurus (@vsoch)
+
+Emeritus:
+  - Avi Deitcher (@deitch)
+  - Josh Dolitsky (@jdolitsky)


### PR DESCRIPTION
This PR aggregates the following changes:
- Move Avi Deitcher (@deitch) to emeritus (as requested by https://github.com/oras-project/community/issues/37)
- Move Josh Dolitsky (@jdolitsky) to emeritus (as requested by https://github.com/oras-project/community/issues/32)