### PR TITLE
fix: Remove old copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 ORAS Authors.
+   Copyright ORAS Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_author: The ORAS Authors
 repo_url: https://github.com/oras-project/oras
 repo_name: oras-project/oras
 edit_uri: ""
-copyright: Copyright &copy; 2021 The ORAS Authors.<br>We are a Cloud Native Computing Foundation sandbox project.
+copyright: Copyright The ORAS Authors.<br>We are a Cloud Native Computing Foundation sandbox project.
 extra_css:
   - assets/stylesheets/extra.css
 plugins:


### PR DESCRIPTION
I don't think year is required on a copyright any longer.