### PR TITLE
docs: fix distribution image

### DIFF
--- a/docs/CLI/6_reference_types.md
+++ b/docs/CLI/6_reference_types.md
@@ -149,7 +149,7 @@ A reference implementation of the ORAS Artifacts Spec is available at [github.co
 To run distribution locally:
 
   ```bash
-  docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v0.0.3-alpha
+  docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.4
   REGISTRY=localhost:5000
   ```
 

--- a/docs/blog/oras-0.15-a-fully-functional-registry-client.md
+++ b/docs/blog/oras-0.15-a-fully-functional-registry-client.md
@@ -24,7 +24,7 @@ This blog post will demonstrate how to use ORAS CLI v0.15 to convert a Docker im
 Run a local instance of the CNCF Distribution Registry, with ORAS Artifacts support (Note: OCI Artifact support is coming soon):
 
 ```bash
-docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.2
+docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.4
 ```
 
 ## Fetch and view the manifest of a sample Docker image


### PR DESCRIPTION
It seems that the `ghcr.io/oras-project/registry:v0.0.3-alpha`
image does not support the OCI reference type (referrers) API,
update to `ghcr.io/oras-project/registry:v1.0.0-rc.4` to fix it.