### PR TITLE
doc: update release cut-off procedure

### DIFF
--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -80,7 +80,7 @@ To update or add new dependencies, run `go get <package name>`.
 3. Open a release PR to
    - Build with latest golang: replace go version of [binary](https://github.com/oras-project/oras/blob/main/.github/workflows/release-github.yml#L32) and [image](https://github.com/oras-project/oras/blob/main/Dockerfile#L14) to latest stable one
    - Update oras version: replace [current stable version](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L20) with upcoming release version
-4. After the release PR got merged, [create an issue](https://github.com/oras-project/oras/issues/new) to call for vote on cutting off a release tag `release-<version>` based on the version update commit.
+4. After the release PR got merged, [create an issue](https://github.com/oras-project/oras/issues/new) to call for vote on cutting off a release branch named `release-<version>` based on the version update commit.
 5. Make fresh clone of the repo after all above steps are completed. Create a new tag for the version prefixed with "v" and push the tag directly to the repo.
     ```sh
     version=1.0.0

--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -99,14 +99,15 @@ To update or add new dependencies, run `go get <package name>`.
     tar -zxf oras_${version}_linux_amd64.tar.gz -C oras-bin
     ./oras-bin/oras version
     ```
-10.  Create armored GPG signatures (`.asc`) using the key in the `KEYS` file.
+
+10. Create armored GPG signatures(`.asc`) using the key in the `KEYS` file.
     ```sh
     for file in `ls`; do
         gpg --armor --detach-sign $file
     done
     ```
-11.  Validate the signatures. Not that the `KEYS` file should be imported with `gpg --import KEYS`. Run some form of the following (adapted from Linux project):
-    ```bash
+11. Validate the signatures. Not that the `KEYS` file should be imported with `gpg --import KEYS`. Run some form of the following (adapted from Linux project):
+    ```sh
     for file in `ls *.asc`; do
         gpg --verify $file
     done
@@ -117,9 +118,9 @@ To update or add new dependencies, run `go get <package name>`.
 
     This release was signed with `BE6F A8DD A48D 4C23 0091 A0A9 276D 8A72 4CE1 C704` (@qweeah's GPG key) which can be found [here](https://github.com/qweeah.gpg).
     ```
-13. Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
-14. Consume beverage of choice.. you're done! Thanks for moving the project forward.
-15. Oh yea, tell people about it in `#oras`
+13.  Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
+14.  Consume beverage of choice.. you're done! Thanks for moving the project forward.
+15.  Oh yea, tell people about it in `#oras`
     
 ### Some Comments
 

--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -80,7 +80,6 @@ To update or add new dependencies, run `go get <package name>`.
 3. Open a release PR to
    - Build with latest golang: replace go version of [binary](https://github.com/oras-project/oras/blob/main/.github/workflows/release-github.yml#L32) and [image](https://github.com/oras-project/oras/blob/main/Dockerfile#L14) to latest stable version
    - Update oras version: replace [current stable version](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L5) with upcoming release version
-
 4. After the release PR got merged, [create an issue](https://github.com/oras-project/oras/issues/new) to call for vote on cutting off a release tag `release-<version>` based on the version update commit.
 5. Make fresh clone the repo after all above steps are completed. Create a new tag for the version prefixed with "v", for example: `git tag v0.15.0`. Push the tag directly to the repo, for example `git push origin v0.15.0`.
     ```sh

--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -76,51 +76,51 @@ To update or add new dependencies, run `go get <package name>`.
 *Note: this section needs a lot of love and automation* 🙂
 
 1. Make sure your GPG is available on GitHub at `https://github.com/<username>.gpg`. This can be added at https://github.com/settings/keys
-2. If you haven't already, open PR to add your GPG key to the [`KEYS`](https://github.com/oras-project/oras/blob/main/KEYS) file (see file for instructions)
-3. Open a release PR to
+1. If you haven't already, open PR to add your GPG key to the [`KEYS`](https://github.com/oras-project/oras/blob/main/KEYS) file (see file for instructions)
+1. Open a release PR to
    - Build with latest golang: replace go version of [binary](https://github.com/oras-project/oras/blob/main/.github/workflows/release-github.yml#L32) and [image](https://github.com/oras-project/oras/blob/main/Dockerfile#L14) to latest stable one
    - Update oras version: replace [current stable version](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L20) with upcoming release version
-4. After the release PR got merged, [create an issue](https://github.com/oras-project/oras/issues/new) to call for vote on cutting off a release branch named `release-<version>` based on the version update commit.
-5. Make fresh clone of the repo after all above steps are completed. Create a new tag for the version prefixed with "v" and push the tag directly to the repo.
+1. After the release PR got merged, [create an issue](https://github.com/oras-project/oras/issues/new) to call for vote on cutting off a release branch named `release-<major>.<minor>` based on the version update commit.
+1. Make fresh clone of the repo after all above steps are completed. Create a new tag for the version prefixed with "v" and push the tag directly to the repo.
     ```sh
     version=1.0.0
     git tag v${version}
     git push origin v${version}
     ```
-6. Wait for GitHub Actions to complete successfully for both the `release-ghcr` and `release-github` pipelines
-7. Download all of the artifacts uploaded to the new GitHub release locally (`*checksums.txt`, `*darwin_amd64.tar.gz`, `*linux_armv7.tar.gz`, `*linux_arm64.tar.gz`, `*linux_amd64.tar.gz`, `*windows_amd64.zip`).
-8. Verify the checksum of the file, downloaded platform should pass the check:
+1. Wait for GitHub Actions to complete successfully for both the `release-ghcr` and `release-github` pipelines
+1. Download all of the artifacts uploaded to the new GitHub release locally (`*checksums.txt`, `*darwin_amd64.tar.gz`, `*linux_armv7.tar.gz`, `*linux_arm64.tar.gz`, `*linux_amd64.tar.gz`, `*windows_amd64.zip`).
+1. Verify the checksum of the file, downloaded platform should pass the check:
     ```sh
     shasum -c oras_${version}_checksums.txt
     ```
-9.  Run version command and make sure that version number and git commit digest is what you expect it to be (same as the commit used to create the tag). Example:
+1.  Run version command and make sure that version number and git commit digest is what you expect it to be (same as the commit used to create the tag). Example:
     ```sh
     mkdir -p oras-bin/
     tar -zxf oras_${version}_linux_amd64.tar.gz -C oras-bin
     ./oras-bin/oras version
     ```
 
-10. Create armored GPG signatures(`.asc`) using the key in the `KEYS` file.
+1. Create armored GPG signatures(`.asc`) using the key in the `KEYS` file.
     ```sh
     for file in `ls`; do
         gpg --armor --detach-sign $file
     done
     ```
-11. Validate the signatures. Not that the `KEYS` file should be imported with `gpg --import KEYS`. Run some form of the following (adapted from Linux project):
+1. Validate the signatures. Not that the `KEYS` file should be imported with `gpg --import KEYS`. Run some form of the following (adapted from Linux project):
     ```sh
     for file in `ls *.asc`; do
         gpg --verify $file
     done
     ```
-12. Click "Edit release" button on the release, and add the `.asc` files created in the previous step. Edit the release description for change logs and also add a note indicating your GPG key used to sign the artifacts. Example (replace with your fingerprint etc.):
+1. Click "Edit release" button on the release, and add the `.asc` files created in the previous step. Edit the release description for change logs and also add a note indicating your GPG key used to sign the artifacts. Example (replace with your fingerprint etc.):
     ```
     ## Notes
 
     This release was signed with `BE6F A8DD A48D 4C23 0091 A0A9 276D 8A72 4CE1 C704` (@qweeah's GPG key) which can be found [here](https://github.com/qweeah.gpg).
     ```
-13.  Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
-14.  Consume beverage of choice.. you're done! Thanks for moving the project forward.
-15.  Oh yea, tell people about it in `#oras`
+1.  Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
+1.  Consume beverage of choice.. you're done! Thanks for moving the project forward.
+1.  Oh yea, tell people about it in `#oras`
     
 ### Some Comments
 

--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -93,7 +93,7 @@ To update or add new dependencies, run `go get <package name>`.
     ```sh
     shasum -c oras_${version}_checksums.txt
     ```
-1.  Run version command and make sure that version number and git commit digest is what you expect it to be (same as the commit used to create the tag). Example:
+1. Run version command and make sure that version number and git commit digest is what you expect it to be (same as the commit used to create the tag). Example:
     ```sh
     mkdir -p oras-bin/
     tar -zxf oras_${version}_linux_amd64.tar.gz -C oras-bin
@@ -118,9 +118,9 @@ To update or add new dependencies, run `go get <package name>`.
 
     This release was signed with `BE6F A8DD A48D 4C23 0091 A0A9 276D 8A72 4CE1 C704` (@qweeah's GPG key) which can be found [here](https://github.com/qweeah.gpg).
     ```
-1.  Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
-1.  Consume beverage of choice.. you're done! Thanks for moving the project forward.
-1.  Oh yea, tell people about it in `#oras`
+1. Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
+1. Consume beverage of choice.. you're done! Thanks for moving the project forward.
+1. Oh yea, tell people about it in `#oras`
     
 ### Some Comments
 

--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -77,9 +77,12 @@ To update or add new dependencies, run `go get <package name>`.
 
 1. Make sure your GPG is available on GitHub at `https://github.com/<username>.gpg`. This can be added at https://github.com/settings/keys
 2. If you haven't already, open PR to add your GPG key to the [`KEYS`](https://github.com/oras-project/oras/blob/main/KEYS) file (see file for instructions)
-3. Look for any reference(e.g. [here](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L5)) to the current stable version. replace with upcoming version and open a PR to check in those changes.
-4. After the PR is merged, cut off the release branch with a tag `release-<version>` and create an issue to call for vote.
-5. Make fresh clone the repo after all above steps are completed and merged. Create a new tag for the version prefixed with "v", for example: `git tag v0.15.0`. Push the tag directly to the repo, for example `git push origin v0.15.0`.
+3. Open a release PR to
+   - Build with latest golang: replace go version of [binary](https://github.com/oras-project/oras/blob/main/.github/workflows/release-github.yml#L32) and [image](https://github.com/oras-project/oras/blob/main/Dockerfile#L14) to latest stable version
+   - Update oras version: replace [current stable version](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L5) with upcoming release version
+
+4. After the release PR got merged, [create an issue](https://github.com/oras-project/oras/issues/new) to call for vote on cutting off a release tag `release-<version>` based on the version update commit.
+5. Make fresh clone the repo after all above steps are completed. Create a new tag for the version prefixed with "v", for example: `git tag v0.15.0`. Push the tag directly to the repo, for example `git push origin v0.15.0`.
     ```sh
     version=0.15.0
     git tag v${version}
@@ -91,7 +94,7 @@ To update or add new dependencies, run `go get <package name>`.
     ```sh
     shasum -c oras_${version}_checksums.txt
     ```
-9. Run version command and make sure that version number and git commit digest is what you expect it to be (same as the commit used to create the tag). Example:
+9.  Run version command and make sure that version number and git commit digest is what you expect it to be (same as the commit used to create the tag). Example:
     ```sh
     mkdir -p oras-bin/
     tar -zxf oras_${version}_linux_amd64.tar.gz -C oras-bin

--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -78,10 +78,10 @@ To update or add new dependencies, run `go get <package name>`.
 1. Make sure your GPG is available on GitHub at `https://github.com/<username>.gpg`. This can be added at https://github.com/settings/keys
 2. If you haven't already, open PR to add your GPG key to the [`KEYS`](https://github.com/oras-project/oras/blob/main/KEYS) file (see file for instructions)
 3. Open a release PR to
-   - Build with latest golang: replace go version of [binary](https://github.com/oras-project/oras/blob/main/.github/workflows/release-github.yml#L32) and [image](https://github.com/oras-project/oras/blob/main/Dockerfile#L14) to latest stable version
+   - Build with latest golang: replace go version of [binary](https://github.com/oras-project/oras/blob/main/.github/workflows/release-github.yml#L32) and [image](https://github.com/oras-project/oras/blob/main/Dockerfile#L14) to latest stable one
    - Update oras version: replace [current stable version](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L5) with upcoming release version
 4. After the release PR got merged, [create an issue](https://github.com/oras-project/oras/issues/new) to call for vote on cutting off a release tag `release-<version>` based on the version update commit.
-5. Make fresh clone the repo after all above steps are completed. Create a new tag for the version prefixed with "v", for example: `git tag v0.15.0`. Push the tag directly to the repo, for example `git push origin v0.15.0`.
+5. Make fresh clone of the repo after all above steps are completed. Create a new tag for the version prefixed with "v", for example: `git tag v0.15.0`. Push the tag directly to the repo, for example `git push origin v0.15.0`.
     ```sh
     version=0.15.0
     git tag v${version}

--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -79,11 +79,11 @@ To update or add new dependencies, run `go get <package name>`.
 2. If you haven't already, open PR to add your GPG key to the [`KEYS`](https://github.com/oras-project/oras/blob/main/KEYS) file (see file for instructions)
 3. Open a release PR to
    - Build with latest golang: replace go version of [binary](https://github.com/oras-project/oras/blob/main/.github/workflows/release-github.yml#L32) and [image](https://github.com/oras-project/oras/blob/main/Dockerfile#L14) to latest stable one
-   - Update oras version: replace [current stable version](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L5) with upcoming release version
+   - Update oras version: replace [current stable version](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L20) with upcoming release version
 4. After the release PR got merged, [create an issue](https://github.com/oras-project/oras/issues/new) to call for vote on cutting off a release tag `release-<version>` based on the version update commit.
-5. Make fresh clone of the repo after all above steps are completed. Create a new tag for the version prefixed with "v", for example: `git tag v0.15.0`. Push the tag directly to the repo, for example `git push origin v0.15.0`.
+5. Make fresh clone of the repo after all above steps are completed. Create a new tag for the version prefixed with "v" and push the tag directly to the repo.
     ```sh
-    version=0.15.0
+    version=1.0.0
     git tag v${version}
     git push origin v${version}
     ```
@@ -115,7 +115,7 @@ To update or add new dependencies, run `go get <package name>`.
     ```
     ## Notes
 
-    This release was signed with `E97F 9DA5 AE2E 39CF 48A1 42B7 852A 7470 A39F B81D` (@jdolitsky's GPG key) which can be found [here](https://github.com/jdolitsky.gpg).
+    This release was signed with `BE6F A8DD A48D 4C23 0091 A0A9 276D 8A72 4CE1 C704` (@qweeah's GPG key) which can be found [here](https://github.com/qweeah.gpg).
     ```
 13. Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
 14. Consume beverage of choice.. you're done! Thanks for moving the project forward.
@@ -144,4 +144,4 @@ Once ready, this should be a doc in the project itself.
 
 oras actually serves 2 purposes: library and utility. All of the above steps, except for the tag, are entirely about the utility.
 
-For better or for worse, semver is tied up with both. As an example, the current issue with the go modules solely affects its inclusion as a library, but it is immediate. It can be fixed by cutting v0.15.0, and the downstream problems go away. yet cutting a release _also_ means all of the above, which are far more complicated.
+For better or for worse, semver is tied up with both. As an example, the current issue with the go modules solely affects its inclusion as a library, but it is immediate. It can be fixed by cutting v1.0.0, and the downstream problems go away. yet cutting a release _also_ means all of the above, which are far more complicated.

--- a/docs/CLI/5_developer_guide.md
+++ b/docs/CLI/5_developer_guide.md
@@ -77,56 +77,56 @@ To update or add new dependencies, run `go get <package name>`.
 
 1. Make sure your GPG is available on GitHub at `https://github.com/<username>.gpg`. This can be added at https://github.com/settings/keys
 2. If you haven't already, open PR to add your GPG key to the [`KEYS`](https://github.com/oras-project/oras/blob/main/KEYS) file (see file for instructions)
-3. Look for any references to the current stable version, and replace with upcoming version. Open a PR with these changes, such as "prepare for <version>". Examples:
-    * https://github.com/oras-project/oras/blob/main/internal/version/version.go#L5
-4. Make fresh clone the repo after all above steps are completed and merged. Create a new tag for the version prefixed with "v", for example: `git tag v0.15.0`. Push the tag directly to the repo, for example `git push origin v0.15.0`.
+3. Look for any reference(e.g. [here](https://github.com/oras-project/oras/blob/main/internal/version/version.go#L5)) to the current stable version. replace with upcoming version and open a PR to check in those changes.
+4. After the PR is merged, cut off the release branch with a tag `release-<version>` and create an issue to call for vote.
+5. Make fresh clone the repo after all above steps are completed and merged. Create a new tag for the version prefixed with "v", for example: `git tag v0.15.0`. Push the tag directly to the repo, for example `git push origin v0.15.0`.
     ```sh
     version=0.15.0
     git tag v${version}
     git push origin v${version}
     ```
-5. Wait for GitHub Actions to complete successfully for both the `release-ghcr` and `release-github` pipelines
-6. Download all of the artifacts uploaded to the new GitHub release locally (`*checksums.txt`, `*darwin_amd64.tar.gz`, `*linux_armv7.tar.gz`, `*linux_arm64.tar.gz`, `*linux_amd64.tar.gz`, `*windows_amd64.zip`).
-7. Verify the checksum of the file, downloaded platform should pass the check:
+6. Wait for GitHub Actions to complete successfully for both the `release-ghcr` and `release-github` pipelines
+7. Download all of the artifacts uploaded to the new GitHub release locally (`*checksums.txt`, `*darwin_amd64.tar.gz`, `*linux_armv7.tar.gz`, `*linux_arm64.tar.gz`, `*linux_amd64.tar.gz`, `*windows_amd64.zip`).
+8. Verify the checksum of the file, downloaded platform should pass the check:
     ```sh
     shasum -c oras_${version}_checksums.txt
     ```
-8. Run version command and make sure that version number and git commit digest is what you expect it to be (same as the commit used to create the tag). Example:
+9. Run version command and make sure that version number and git commit digest is what you expect it to be (same as the commit used to create the tag). Example:
     ```sh
     mkdir -p oras-bin/
     tar -zxf oras_${version}_linux_amd64.tar.gz -C oras-bin
     ./oras-bin/oras version
     ```
-9. Create armored GPG signatures (`.asc`) using the key in the `KEYS` file.
+10.  Create armored GPG signatures (`.asc`) using the key in the `KEYS` file.
     ```sh
     for file in `ls`; do
         gpg --armor --detach-sign $file
     done
     ```
-10. Validate the signatures. Not that the `KEYS` file should be imported with `gpg --import KEYS`. Run some form of the following (adapted from Linux project):
+11.  Validate the signatures. Not that the `KEYS` file should be imported with `gpg --import KEYS`. Run some form of the following (adapted from Linux project):
     ```bash
     for file in `ls *.asc`; do
         gpg --verify $file
     done
     ```
-11. Click "Edit release" button on the release, and add the `.asc` files created in the previous step. Edit the release description for change logs and also add a note indicating your GPG key used to sign the artifacts. Example (replace with your fingerprint etc.):
+12. Click "Edit release" button on the release, and add the `.asc` files created in the previous step. Edit the release description for change logs and also add a note indicating your GPG key used to sign the artifacts. Example (replace with your fingerprint etc.):
     ```
     ## Notes
 
     This release was signed with `E97F 9DA5 AE2E 39CF 48A1 42B7 852A 7470 A39F B81D` (@jdolitsky's GPG key) which can be found [here](https://github.com/jdolitsky.gpg).
     ```
-12. Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
-13. Consume beverage of choice.. you're done! Thanks for moving the project forward.
-14. Oh yea, tell people about it in `#oras`
+13. Click "Publish Release" button to save. Double-check that the release contains a corresponding `.asc` file for each release artifact.
+14. Consume beverage of choice.. you're done! Thanks for moving the project forward.
+15. Oh yea, tell people about it in `#oras`
     
 ### Some Comments
 
 There is a large number of steps here, mostly manual. Here are some comments and/or thoughts on it.
 
 * Step 3: Editing files for stable version. I can see that in one place, say, `README.md`. But do we really have to edit the code? Could we not use build-time flags as in `go build -ldflags="-X main.Version=foo"` or similar?
-* Step 5: This is the heart of the release. Adding a tag triggers a github release and an image build pushed to GHCR.
-* Steps 6-12: These are all signing and verifying. Of course, it is possible that GH Actions built and released something other than what we thought, but we cannot counter every single possible risk. It still would be nice if we could automate this somehow.
-* Step 14: :beer:
+* Step 6: This is the heart of the release. Adding a tag triggers a github release and an image build pushed to GHCR.
+* Steps 7-13: These are all signing and verifying. Of course, it is possible that GH Actions built and released something other than what we thought, but we cannot counter every single possible risk. It still would be nice if we could automate this somehow.
+* Step 15: :beer:
 
 From a documentation perspective, I would break this down into sections:
 


### PR DESCRIPTION
This PR introduces how should we cut off a release branch and call for vote, which should be applied to oras CLI 1.0.0 release.