### PR TITLE
Fixed broken links in introduction page for CLI and client libraries

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,8 +11,8 @@ Registries are evolving as generic artifact stores.
 To enable this goal, the ORAS project provides a way to
 push and pull OCI Artifacts to and from OCI Registries.
 
-Users seeking a generic registry client can benefit from the [ORAS CLI](CLI/), while
-developers can build their own clients on top of one of the [ORAS client libraries](./client_libraries/).
+Users seeking a generic registry client can benefit from the [ORAS CLI](/docs/category/CLI), while
+developers can build their own clients on top of one of the [ORAS client libraries](./category/client-libraries).
 
 ## What are OCI Registries?
 
@@ -67,6 +67,7 @@ application/vnd.unknown.config.v1+json
 Authors of new OCI Artifacts are thus encouraged to define their own media types specific to
 their artifact, which their custom client(s) know how to operate on.
 
-If you wish to start publishing OCI Artifacts right away, take a look at the [ORAS CLI](CLI/).
+If you wish to start publishing OCI Artifacts right away, take a look at the [ORAS CLI](/docs/category/CLI).
 Developers who wish to provide their own user experience should use one of the
-[ORAS client libraries](./client_libraries/).
+[ORAS client libraries](./category/client-libraries).
+


### PR DESCRIPTION
**I was learning about the working of ORAS to contribute to it in LFX term and while browsing through documentation, I found few broken links in the [Introduction page](https://oras.land/docs/).**

https://github.com/oras-project/oras-www/assets/74777863/3edb4a13-bd44-439c-b1e0-24525582a2e1

![Screenshot from 2023-05-12 21-59-57](https://github.com/oras-project/oras-www/assets/74777863/73b44fc3-a26d-4c38-95e4-2fe958f0731e)



**Thus, I tried to fix it,**

https://github.com/oras-project/oras-www/assets/74777863/8ab985a2-e534-4019-b8e2-4f91048779a1

**Hope it helps :)**



