### PR TITLE
chore: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Update dependabot.yml file to update dependencies weekly. This will help us review PRs and maintain the dependencies in a neater way.

Also added `ignore` key to ignore the major version upgrades of dependencies (#168, #166, #164) which might cause breaking down of the website. This will also help reduce unnecessary PRs. Security updates are unaffected by this setting. 

More info here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore