### PR TITLE
updated oras_blob_fetch.mdx

### DIFF
--- a/docs/CLI_Reference/oras_blob_fetch.mdx
+++ b/docs/CLI_Reference/oras_blob_fetch.mdx
@@ -13,7 +13,7 @@ oras blob fetch [flags] {--output <file> | --descriptor} <name>@<digest>
 
 ## Examples
 
-fetch a blob with a specific reference, determine its size using jq, and use pv to display the progress while redirecting the output to a file named layer.bin
+Fetch a blob with a specific reference, determine its size using jq, and use pv to display the progress while redirecting the output to a file named layer.bin
 
 ```bash
  $blob_ref=ghcr.io/oras-project/oras@sha256:74529e03eae02d1fff5c05e9a6ec2089e1f5ae96421169c29a7c165346e042e4

--- a/docs/CLI_Reference/oras_blob_fetch.mdx
+++ b/docs/CLI_Reference/oras_blob_fetch.mdx
@@ -13,14 +13,6 @@ oras blob fetch [flags] {--output <file> | --descriptor} <name>@<digest>
 
 ## Examples
 
-Fetch a blob with a specific reference, determine its size using jq, and use pv to display the progress while redirecting the output to a file named layer.bin
-
-```bash
- $blob_ref=ghcr.io/oras-project/oras@sha256:74529e03eae02d1fff5c05e9a6ec2089e1f5ae96421169c29a7c165346e042e4
- $size=$(oras blob fetch --descriptor $blob_ref | jq -r .size)
- $oras blob fetch $blob_ref --output - | pv -s $size > layer.bin
-```
-
 Fetch a blob from registry and save it to a local file:
 
 ```bash
@@ -55,6 +47,14 @@ Fetch and print a blob from OCI image layout archive file 'layout.tar':
 
 ```bash
 oras blob fetch --oci-layout --output - layout.tar@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
+```
+
+Fetch a blob with a specific reference, determine its size using jq, and use pv to display the progress while redirecting the output to a file named layer.bin
+
+```bash
+ $blob_ref=ghcr.io/oras-project/oras@sha256:74529e03eae02d1fff5c05e9a6ec2089e1f5ae96421169c29a7c165346e042e4
+ $size=$(oras blob fetch --descriptor $blob_ref | jq -r .size)
+ $oras blob fetch $blob_ref --output - | pv -s $size > layer.bin
 ```
 
 ## Options

--- a/docs/CLI_Reference/oras_blob_fetch.mdx
+++ b/docs/CLI_Reference/oras_blob_fetch.mdx
@@ -49,7 +49,7 @@ Fetch and print a blob from OCI image layout archive file 'layout.tar':
 oras blob fetch --oci-layout --output - layout.tar@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
 ```
 
-Fetch a blob with a specific reference, determine its size using jq, and use pv to display the progress while redirecting the output to a file named layer.bin
+Fetch a blob with a specific reference, determine its size using `jq`, and use `pv` to display the progress while redirecting the output to a file named `layer.bin`:
 
 ```bash
  $blob_ref=ghcr.io/oras-project/oras@sha256:74529e03eae02d1fff5c05e9a6ec2089e1f5ae96421169c29a7c165346e042e4

--- a/docs/CLI_Reference/oras_blob_fetch.mdx
+++ b/docs/CLI_Reference/oras_blob_fetch.mdx
@@ -13,6 +13,14 @@ oras blob fetch [flags] {--output <file> | --descriptor} <name>@<digest>
 
 ## Examples
 
+fetch a blob with a specific reference, determine its size using jq, and use pv to display the progress while redirecting the output to a file named layer.bin
+
+```bash
+ $blob_ref=ghcr.io/oras-project/oras@sha256:74529e03eae02d1fff5c05e9a6ec2089e1f5ae96421169c29a7c165346e042e4
+ $size=$(oras blob fetch --descriptor $blob_ref | jq -r .size)
+ $oras blob fetch $blob_ref --output - | pv -s $size > layer.bin
+```
+
 Fetch a blob from registry and save it to a local file:
 
 ```bash


### PR DESCRIPTION
Closes: #130


By using jq and pv, one can show the content downloading progress when using ORAS. This demonstrates how to fetch a blob with a specific reference, determine its size using jq, and use pv to display the progress while redirecting the output to a file named layer.bin.

```
$ blob_ref=ghcr.io/oras-project/oras@sha256:74529e03eae02d1fff5c05e9a6ec2089e1f5ae96421169c29a7c165346e042e4
$ size=$(oras blob fetch --descriptor $blob_ref | jq -r .size)
$ oras blob fetch $blob_ref --output - | pv -s $size > layer.bin
```