### PR TITLE
feat: add gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: npm install
+    command: npm start
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Source for ORAS website and documentation
   </a>
 </div>
 
+# Development
+
+## Online one-click setup
+
+You can use Gitpod (a free, online, VS Code-like IDE) for contributing. With a single click, it will launch a workspace (for Docusaurus 2) and automatically:
+
+* clone the docusaurus repo.
+* install the dependencies.
+* run `npm start`
+
+So that you can start contributing straight away.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/oras-project/oras-www)
+
 ## System Requirements
 
 * [Node.js v16.x](https://nodejs.org/en/download/) and above

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Source for ORAS website and documentation
 
 ## Online one-click setup
 
-You can use Gitpod (a free, online, VS Code-like IDE) for contributing. With a single click, it will launch a workspace (for Docusaurus 2) and automatically:
+You can use Gitpod (a free, online, VS Code-like IDE) for contributing. With a single click, it will launch a workspace (for Docusaurus 2) automatically:
 
 * clone the docusaurus repo.
 * install the dependencies.


### PR DESCRIPTION
Added Gitpod support (Cloud IDE) for oras-www repository for one-click setup of our documentation website. Contributors can start contributing right away without worrying about system requirements. 