### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/CLI/manifest_config.mdx
+++ b/docs/CLI/manifest_config.mdx
@@ -111,7 +111,7 @@ Additionally, the latest version of `dockerd` recognizes OCI manifests and does 
 ## Push / Pull config
 
 As mentioned in the beginning of this doc, the manifest config is not used by `oras` and is not worth pulling in most scenarios.
-However, it is still possible to push pullable config with the `oras` CLI by leveraging [Manifest Annotations](../manifest_annotations).
+However, it is still possible to push pullable config with the `oras` CLI by leveraging [Manifest Annotations](/cli/manifest_annotations).
 
 ```
 $ cat config.json

--- a/docs/CLI/manifest_config.mdx
+++ b/docs/CLI/manifest_config.mdx
@@ -111,7 +111,7 @@ Additionally, the latest version of `dockerd` recognizes OCI manifests and does 
 ## Push / Pull config
 
 As mentioned in the beginning of this doc, the manifest config is not used by `oras` and is not worth pulling in most scenarios.
-However, it is still possible to push pullable config with the `oras` CLI by leveraging [Manifest Annotations](./manifest_annotations).
+However, it is still possible to push pullable config with the `oras` CLI by leveraging [Manifest Annotations](../manifest_annotations).
 
 ```
 $ cat config.json


### PR DESCRIPTION
Link to Manifest Annotations is broken