### PR TITLE
docs: restructure community guides and resources

### DIFF
--- a/docs/community/_category_.json
+++ b/docs/community/_category_.json
@@ -1,0 +1,8 @@
+{
+    "label": "Community",
+    "position": 50,
+    "link": {
+        "type": "generated-index",
+        "description": "Community Guide"
+    }
+}

--- a/docs/community/community_resources.mdx
+++ b/docs/community/community_resources.mdx
@@ -1,6 +1,6 @@
 ---
-title: Community
-sidebar_position: 50
+title: Community Resources
+sidebar_position: 10
 ---
 
 # Welcome to the ORAS Project community.

--- a/docs/community/contributing_guide.mdx
+++ b/docs/community/contributing_guide.mdx
@@ -1,6 +1,6 @@
 ---
-title: Contributing
-sidebar_position: 60
+title: Contributing Guide
+sidebar_position: 20
 ---
 
 # Contributing Guide

--- a/docs/community/developer_guide.mdx
+++ b/docs/community/developer_guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Developer Guide
-sidebar_position: 6
+sidebar_position: 30
 ---
 
 # Developer Guide


### PR DESCRIPTION
This PR brings all community guides and resources under the "Community" section.

Fixes some issues from PR #202. 