### PR TITLE
docs: update installation guide with validation for cli binaries

### DIFF
--- a/docs/how_to_guides/verifying_binaries.mdx
+++ b/docs/how_to_guides/verifying_binaries.mdx
@@ -3,14 +3,16 @@ title: Validating ORAS CLI Binaries
 sidebar_position: 10
 ---
 
-# Validating the Checksum of ORAS CLI Binaries
+# Validating ORAS CLI Binaries
 
 After finding your [target release](https://github.com/oras-project/oras/releases), 
 you may find the releaser's information under the `notes` section.
 
 The following commands can be used to verify the ORAS CLI binaries using GPG:
 
-1. First, we import the releaser's GPG Key which can be used for verification (here we have imported [Billy Zha](https://github.com/qweeah)'s key):
+### Step 1: 
+
+First, we import the releaser's GPG Key which can be used for verification (here we have imported [Billy Zha](https://github.com/qweeah)'s key):
 
 ```
 $ curl -sSL https://github.com/qweeah.gpg | gpg --import -
@@ -18,7 +20,9 @@ $ curl -sSL https://github.com/qweeah.gpg | gpg --import -
 
 You can find the [GPG keys](https://github.com/oras-project/oras/blob/main/KEYS) which have been used for ORAS releases.
 
-2. You can run the following command to check if the key has been imported:
+### Step 2: 
+
+You can run the following command to check if the key has been imported:
 
 ```
 $ gpg --list-keys
@@ -27,7 +31,9 @@ pub   rsa4096 2023-02-28 [SC] [expires: 2024-02-28]
 uid           [ unknown] Billy Zha <jinzha1@microsoft.com>
 ```
 
-3. Verify our binaries using the command:
+### Step 3: 
+
+Verify our binaries using the command:
 
 ```
 $ gpg --verify oras_1.0.0_linux_amd64.tar.gz.asc oras_1.0.0_linux_amd64.tar.gz

--- a/docs/how_to_guides/verifying_binaries.mdx
+++ b/docs/how_to_guides/verifying_binaries.mdx
@@ -1,0 +1,37 @@
+---
+title: Validating ORAS CLI Binaries
+sidebar_position: 10
+---
+
+# Validating the Checksum of ORAS CLI Binaries
+
+After finding your [target release](https://github.com/oras-project/oras/releases), 
+you may find the releaser's information under the `notes` section.
+
+The following commands can be used to verify the ORAS CLI binaries using GPG:
+
+1. First, we import the releaser's GPG Key which can be used for verification (here we have imported [Billy Zha](https://github.com/qweeah)'s key):
+
+```
+$ curl -sSL https://github.com/qweeah.gpg | gpg --import -
+```
+
+You can find the [GPG keys](https://github.com/oras-project/oras/blob/main/KEYS) which have been used for ORAS releases.
+
+2. You can run the following command to check if the key has been imported:
+
+```
+$ gpg --list-keys
+pub   rsa4096 2023-02-28 [SC] [expires: 2024-02-28]
+      BE6FA8DDA48D4C230091A0A9276D8A724CE1C704
+uid           [ unknown] Billy Zha <jinzha1@microsoft.com>
+```
+
+3. Verify our binaries using the command:
+
+```
+$ gpg --verify oras_1.0.0_linux_amd64.tar.gz.asc oras_1.0.0_linux_amd64.tar.gz
+gpg: Signature made Mon Mar 20 15:51:28 2023 IST
+gpg:                using RSA key BE6FA8DDA48D4C230091A0A9276D8A724CE1C704
+gpg: Good signature from "Billy Zha <jinzha1@microsoft.com>" [unknown]
+```

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -124,3 +124,41 @@ Go version:     go1.20.2
 Git commit:     b58e7b910ca556973d111e9bd734a71baef03db2
 Git tree state: clean
 ```
+
+## To Validate the Checksum of ORAS CLI Binaries
+
+
+The following commands can be used to verify the ORAS CLI binaries using GPG:
+
+1. First, we import a GPG Key which can be used for verification:
+
+```
+$ curl -sSL https://github.com/qweeah.gpg | gpg --import -
+gpg: key 276D8A724CE1C704: "Billy Zha <jinzha1@microsoft.com>" not changed
+gpg: Total number processed: 1
+gpg: unchanged: 1
+```
+
+2. Next, we need to sign and save the binary:
+
+```
+$ gpg --armor --detach-sign $file
+```
+
+The signed file gets saved with a `.asc` extenstion.
+
+3. In order to verify the binaries against a trusted source, we run the following command to declare the trust,
+
+```
+gpg --edit-key qweeah trust
+```
+Here, we are required to choose "4 = I trust fully"
+
+4. Last but not the least, we verify our binaries using the command,
+
+```
+$ gpg --verify oras_1.0.0_linux_amd64.tar.gz.asc oras_1.0.0_linux_amd64.tar.gz
+gpg: Signature made Wed Jul 12 00:14:49 2023 IST
+gpg: using RSA key 03387B6C7C3D9BD9FC2D318670CE7E4FFF445FC8
+gpg: Good signature from "Deepesha <deepesha.3007@gmail.com>" [ultimate]
+```

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -127,14 +127,18 @@ Git tree state: clean
 
 ## To Validate the Checksum of ORAS CLI Binaries
 
+After finding your [target release](https://github.com/oras-project/oras/releases), 
+you may find the releaser's information under the `notes` section.
 
 The following commands can be used to verify the ORAS CLI binaries using GPG:
 
-1. First, we import a GPG Key which can be used for verification:
+1. First, we import the releaser's GPG Key which can be used for verification (here we have imported [Billy Zha](https://github.com/qweeah)'s key):
 
 ```
 $ curl -sSL https://github.com/qweeah.gpg | gpg --import -
 ```
+
+You can find the [GPG keys](https://github.com/oras-project/oras/blob/main/KEYS) which have been used for ORAS releases.
 
 2. You can run the following command to check if the key has been imported:
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -125,35 +125,4 @@ Git commit:     b58e7b910ca556973d111e9bd734a71baef03db2
 Git tree state: clean
 ```
 
-## To Validate the Checksum of ORAS CLI Binaries
-
-After finding your [target release](https://github.com/oras-project/oras/releases), 
-you may find the releaser's information under the `notes` section.
-
-The following commands can be used to verify the ORAS CLI binaries using GPG:
-
-1. First, we import the releaser's GPG Key which can be used for verification (here we have imported [Billy Zha](https://github.com/qweeah)'s key):
-
-```
-$ curl -sSL https://github.com/qweeah.gpg | gpg --import -
-```
-
-You can find the [GPG keys](https://github.com/oras-project/oras/blob/main/KEYS) which have been used for ORAS releases.
-
-2. You can run the following command to check if the key has been imported:
-
-```
-$ gpg --list-keys
-pub   rsa4096 2023-02-28 [SC] [expires: 2024-02-28]
-      BE6FA8DDA48D4C230091A0A9276D8A724CE1C704
-uid           [ unknown] Billy Zha <jinzha1@microsoft.com>
-```
-
-3. Verify our binaries using the command:
-
-```
-$ gpg --verify oras_1.0.0_linux_amd64.tar.gz.asc oras_1.0.0_linux_amd64.tar.gz
-gpg: Signature made Mon Mar 20 15:51:28 2023 IST
-gpg:                using RSA key BE6FA8DDA48D4C230091A0A9276D8A724CE1C704
-gpg: Good signature from "Billy Zha <jinzha1@microsoft.com>" [unknown]
-```
+You can check out our [how-to guide](./how_to_guides/verifying_binaries.mdx) if you would like to verify ORAS CLI Binaries.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -139,22 +139,7 @@ gpg: Total number processed: 1
 gpg: unchanged: 1
 ```
 
-2. Next, we need to sign and save the binary:
-
-```
-$ gpg --armor --detach-sign $file
-```
-
-The signed file gets saved with a `.asc` extenstion.
-
-3. In order to verify the binaries against a trusted source, we run the following command to declare the trust,
-
-```
-gpg --edit-key qweeah trust
-```
-Here, we are required to choose "4 = I trust fully"
-
-4. Verify our binaries using the command,
+2. Verify our binaries using the command,
 
 ```
 $ gpg --verify oras_1.0.0_linux_amd64.tar.gz.asc oras_1.0.0_linux_amd64.tar.gz

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -154,7 +154,7 @@ gpg --edit-key qweeah trust
 ```
 Here, we are required to choose "4 = I trust fully"
 
-4. Last but not the least, we verify our binaries using the command,
+4. Verify our binaries using the command,
 
 ```
 $ gpg --verify oras_1.0.0_linux_amd64.tar.gz.asc oras_1.0.0_linux_amd64.tar.gz

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -134,16 +134,22 @@ The following commands can be used to verify the ORAS CLI binaries using GPG:
 
 ```
 $ curl -sSL https://github.com/qweeah.gpg | gpg --import -
-gpg: key 276D8A724CE1C704: "Billy Zha <jinzha1@microsoft.com>" not changed
-gpg: Total number processed: 1
-gpg: unchanged: 1
 ```
 
-2. Verify our binaries using the command,
+2. You can run the following command to check if the key has been imported:
+
+```
+$ gpg --list-keys
+pub   rsa4096 2023-02-28 [SC] [expires: 2024-02-28]
+      BE6FA8DDA48D4C230091A0A9276D8A724CE1C704
+uid           [ unknown] Billy Zha <jinzha1@microsoft.com>
+```
+
+3. Verify our binaries using the command:
 
 ```
 $ gpg --verify oras_1.0.0_linux_amd64.tar.gz.asc oras_1.0.0_linux_amd64.tar.gz
-gpg: Signature made Wed Jul 12 00:14:49 2023 IST
-gpg: using RSA key 03387B6C7C3D9BD9FC2D318670CE7E4FFF445FC8
-gpg: Good signature from "Deepesha <deepesha.3007@gmail.com>" [ultimate]
+gpg: Signature made Mon Mar 20 15:51:28 2023 IST
+gpg:                using RSA key BE6FA8DDA48D4C230091A0A9276D8A724CE1C704
+gpg: Good signature from "Billy Zha <jinzha1@microsoft.com>" [unknown]
 ```


### PR DESCRIPTION
This PR brings the installation guide to the top level according to the new directory structure. 

It also fixes #69. 