### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/Tutorials/zot-registry-tutorial.mdx
+++ b/docs/Tutorials/zot-registry-tutorial.mdx
@@ -11,7 +11,7 @@ OCI registries are like a single location where container images and other artif
 
 We will be using zot registry in this guide. Zot registry is an OCI-native container registry for distributing container images and OCI artifacts.
 
-In order to follow the steps given, you would be required to install the ORAS CLI. You can follow the [installation guide](../installation.mdx) to do so. 
+In order to follow the steps given, you would be required to install the ORAS CLI. You can follow the [installation guide](/docs/installation) to do so. 
 
 ### Phase 1: To Install Zot Registry 
 

--- a/docs/Tutorials/zot-registry-tutorial.mdx
+++ b/docs/Tutorials/zot-registry-tutorial.mdx
@@ -11,7 +11,7 @@ OCI registries are like a single location where container images and other artif
 
 We will be using zot registry in this guide. Zot registry is an OCI-native container registry for distributing container images and OCI artifacts.
 
-In order to follow the steps given, you would be required to install the ORAS CLI. You can follow the [installation guide](https://oras.land/docs/CLI/installation) to do so. 
+In order to follow the steps given, you would be required to install the ORAS CLI. You can follow the [installation guide](../installation.mdx) to do so. 
 
 ### Phase 1: To Install Zot Registry 
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,7 +11,7 @@ Registries are evolving as generic artifact stores.
 To enable this goal, the ORAS project provides a way to
 push and pull OCI Artifacts to and from OCI Registries.
 
-Users seeking a generic registry client can benefit from the [ORAS CLI](./cli/installation), while
+Users seeking a generic registry client can benefit from the [ORAS CLI](./installation.mdx), while
 developers can build their own clients on top of one of the [ORAS client libraries](./client_libraries/overview).
 
 ## What are OCI Registries?
@@ -41,9 +41,9 @@ The [OCI Artifacts](https://github.com/opencontainers/artifacts) project is an a
 define an opinionated way to leverage OCI Registries for arbitrary artifacts without masquerading
 them as container images.
 
-Specifically, [OCI Image Manifests](https://github.com/opencontainers/image-spec/blob/master/manifest.md)
+Specifically, [OCI Image Manifests](https://github.com/opencontainers/image-spec/blob/main/manifest.md)
 have a required field known as `config.mediaType`. According to the
-[guidelines](https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md)
+[guidelines](https://github.com/opencontainers/artifacts/blob/main/artifact-authors.md)
 provided by OCI Artifacts, this field provides the ability to differentiate between various types of artifacts.
 
 Artifacts stored in an OCI Registry using this method are referred to herein as **OCI Artifacts**.
@@ -67,7 +67,6 @@ application/vnd.unknown.config.v1+json
 Authors of new OCI Artifacts are thus encouraged to define their own media types specific to
 their artifact, which their custom client(s) know how to operate on.
 
-If you wish to start publishing OCI Artifacts right away, take a look at the [ORAS CLI](./cli/installation).
+If you wish to start publishing OCI Artifacts right away, take a look at the [ORAS CLI](./installation.mdx).
 Developers who wish to provide their own user experience should use one of the
 [ORAS client libraries](./client_libraries/overview).
-

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,7 +11,7 @@ Registries are evolving as generic artifact stores.
 To enable this goal, the ORAS project provides a way to
 push and pull OCI Artifacts to and from OCI Registries.
 
-Users seeking a generic registry client can benefit from the [ORAS CLI](./installation.mdx), while
+Users seeking a generic registry client can benefit from the [ORAS CLI](./installation), while
 developers can build their own clients on top of one of the [ORAS client libraries](./client_libraries/overview).
 
 ## What are OCI Registries?

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -67,6 +67,6 @@ application/vnd.unknown.config.v1+json
 Authors of new OCI Artifacts are thus encouraged to define their own media types specific to
 their artifact, which their custom client(s) know how to operate on.
 
-If you wish to start publishing OCI Artifacts right away, take a look at the [ORAS CLI](./installation.mdx).
+If you wish to start publishing OCI Artifacts right away, take a look at the [ORAS CLI](./installation).
 Developers who wish to provide their own user experience should use one of the
 [ORAS client libraries](./client_libraries/overview).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,12 +149,16 @@ const config = {
                 to: '/docs/',
               },
               {
-                label: 'CLI',
-                to: '/docs/cli/installation',
+                label: 'Installation',
+                to: '/docs/installation',
               },
               {
-                label: 'CLI Reference',
-                to: '/docs/cli_reference/use_oras_cli',
+                label: 'How-to Guides',
+                to: '/docs/how_to_guides/authentication',
+              },
+              {
+                label: 'ORAS Commands',
+                to: '/docs/commands/use_oras_cli',
               },
               {
                 label: 'Client Libraries',

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -10,7 +10,7 @@ export default function Header() {
                 <h1>ORAS</h1>
                 <h3>Distribute Artifacts Across OCI Registries With Ease</h3>
                 <div className={styles.header_content_input}>
-                    <Link to="/docs/cli/installation" className='button button--secondary button--lg'>Get Started</Link>
+                    <Link to="/docs/installation" className='button button--secondary button--lg'>Get Started</Link>
                 </div>
             </div>
             <div className={styles.header_image}>

--- a/src/components/ORAS_CLI/index.jsx
+++ b/src/components/ORAS_CLI/index.jsx
@@ -28,7 +28,7 @@ export default function ORASCLI() {
         <div className={[styles.orascli, styles.section_padding].join(' ')}>
             <div className={styles.orascli_content}>
                 <h1>Install ORAS CLI in seconds</h1>
-                <p>You can install ORAS CLI on different systems or set up in GitHub Actions in just a few seconds. See more <a href="/docs/cli/installation">installation methods</a>.</p>
+                <p>You can install ORAS CLI on different systems or set up in GitHub Actions in just a few seconds. See more <a href="/docs/installation">installation methods</a>.</p>
             </div>
             <div className={styles.orascli_cli}>
                 <TerminalWindow>


### PR DESCRIPTION
This PR updates all the links not working and renames "Tutorial" to "tutorial" for uniformity.