### PR TITLE
docs: Update guide to authenticate with OCI Registries

### DIFF
--- a/docs/how_to_guides/authentication.mdx
+++ b/docs/how_to_guides/authentication.mdx
@@ -5,9 +5,15 @@ sidebar_position: 1
 
 # Authentication
 
-Run `oras login` in advance for any private registries. By default, this will store credentials in `~/.docker/config.json` *(same file used by the docker client)*. If you have previously authenticated to a registry using `docker login`, the credentials will be reused.
+There are two ways we will be covering in this guide to authenticate with OCI Registries.
 
-Use the `-c`/`--config` option to specify an alternate location.
+### Method 1: Authentication Using the `config` File
+
+This method is straightforward but insecure. It may be used for testing purposes. In this method, the command will store the credentials in `~/.docker/config.json` which is the same file used as the docker client. 
+
+Please note that if you have previously used `docker login`, the credentials will get reused.
+
+You may use the `-c`/`--config` option to specify an alternate location.
 
 :::info
 
@@ -15,10 +21,55 @@ While ORAS leverages the local docker client config store, ORAS does NOT have a 
 
 :::
 
-`oras` also accepts explicit credentials via options, for example,
+You can either make use of [`oras login`](../commands/oras_login) or provide explicit credentials via options, for example,
 
 ```
 oras pull -u username -p password myregistry.io/myimage:latest
 ```
+However, you will get a warning message stating that the credentials will be stored unencrypted in the `config` file.
 
-See [Supported Registries] for registry specific authentication usage.
+### Method 2: Authentication Using Docker Credential Helper
+
+The native keychain of the operating system is an external credential store that the Docker Engine can use to store user credentials. It is safer to use an external store than to keep credentials in the Docker configuration file (`~/.docker/config.json`).
+
+An external helper program is needed to interact with a specific keychain or external store. Docker requires the helper program to be in the client’s host `$PATH`.
+
+Prerequisites to follow through with these commands:
+1. According to your operating system, you may download a credential helper from among these:
+    - [D-Bus Secret Service](https://github.com/docker/docker-credential-helpers/releases) 
+    - [Apple macOS keychain](https://github.com/docker/docker-credential-helpers/releases)
+    - [Microsoft Windows Credential Manager](https://github.com/docker/docker-credential-helpers/releases)
+    - [pass](https://www.passwordstore.org/)
+2. [Docker Credential Helpers](https://github.com/docker/docker-credential-helpers)
+
+**Step 1**
+
+Configure the credential store in the `~/.docker/config.json` file. Your file should look similar to this:
+
+```
+{
+  ...
+  "credStore": "pass"
+  ...
+}
+```
+
+**Note**: Please replace pass with the credential helper you want to use. 
+
+**Step 2**
+
+Before running the [`oras login`](../commands/oras_login) command, make sure you have logged out once so that the next time you enter your credentials, they get stored in the credential store.
+
+```
+$ oras login localhost:5000
+Username: deepeshaburse
+Password: 
+Login Succeeded
+```
+
+Your credential helper has been set up, the next time you run `oras login`, you should see an output like this:
+
+```
+Authenticating with existing credentials...
+Login Succeeded
+```


### PR DESCRIPTION
This PR adds a how-to guide for authenticating with OCI Registries.

It covers two methods:
1. Using `config.json`
2. Using docker credential helper