### PR TITLE
docs: change position of installation guide

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-sidebar_position: 0
+sidebar_position: 15
 ---
 
 # Installation


### PR DESCRIPTION
This PR brings the introduction back on top, above the installation guide.