### PR TITLE
docs: rename adopters

### DIFF
--- a/docs/compatible_oci_registries.mdx
+++ b/docs/compatible_oci_registries.mdx
@@ -1,9 +1,9 @@
 ---
-title: Adopters
+title: Compatible OCI Registries
 sidebar_position: 70
 ---
 
-# Adopters
+# Compatible OCI Registries
 
 This page contains a list of projects leveraging ORAS, as well as
 registries that are known to support [OCI Artifacts][artifacts].


### PR DESCRIPTION
This PR renames the section `adopters` to `Compatible OCI Registries`.