### PR TITLE
docs: update supported spec version for Go SDK

### DIFF
--- a/docs/client_libraries/go.mdx
+++ b/docs/client_libraries/go.mdx
@@ -10,7 +10,7 @@ Source code: [github.com/oras-project/oras-go](https://github.com/oras-project/o
 ## Introduction
 
 The ORAS Go client library provides the ability to replicate artifacts between different [Targets](./overview.mdx#target).  
-Furthermore, the version `v2` is a registry client conforming [image-spec v1.1.0-rc.2](https://github.com/opencontainers/image-spec/releases/tag/v1.1.0-rc2) and [distribution-spec v1.1.0-rc1](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md).
+Furthermore, the version `v2` is a registry client conforming [image-spec v1.1.0-rc.5](https://github.com/opencontainers/image-spec/releases/tag/v1.1.0-rc5) and [distribution-spec v1.1.0-rc3](https://github.com/opencontainers/distribution-spec/releases/tag/v1.1.0-rc3).
 
 Using the ORAS Go client library, you can develop your own registry client:
 


### PR DESCRIPTION
1. Update supported `image-spec` version to `v1.1.0-rc5`.
2. Update supported `distribution-spec` version to `v1.1.0-rc3`.

Page preview: https://deploy-preview-273--oras-project.netlify.app/docs/client_libraries/go