### PR TITLE
docs: fix typo in artifact.mdx

### DIFF
--- a/docs/concepts/artifact.mdx
+++ b/docs/concepts/artifact.mdx
@@ -225,7 +225,7 @@ artifact depending on the required condition.
 ## Best Practices and Limitations
 
 While working with OCI artifacts, keep in mind that client tools and registries
-are in the process of implementiong v1.1 version of the OCI image and distribution specifications.
+are in the process of implementing v1.1 version of the OCI image and distribution specifications.
 
 - When clients or registries support the `artifactType` property, the `config.mediaType`
 can be set to _application/vnd.oci.empty.v1+json_ if the artifact doesn't have a config.


### PR DESCRIPTION
Just a little typo. (Also file had no ending newline and the web editor added one.)