### PR TITLE
chore: Move the `oras cp` page to the correct file name

### DIFF
--- a/docs/commands/oras_cp.mdx
+++ b/docs/commands/oras_cp.mdx
@@ -46,7 +46,7 @@ oras cp -r localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 Copy an artifact and referrers using specific methods for the Referrers API:
 
 ```bash
-oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag     localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1 
+oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag     localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 ```
 
 Copy certain platform of an artifact:


### PR DESCRIPTION
To be consistent with file names for commands, the file name sould be `oras_cp.mdx`

Partial: #287