### PR TITLE
doc: update snap install command

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -20,7 +20,7 @@ brew install oras
 Install `oras` using [Snap](https://snapcraft.io/store):
 
 ```bash
-snap install oras
+snap install oras --classic
 ```
 
 ## Release artifacts


### PR DESCRIPTION
Since the confinement level of ORAS snap release has already changed to `classic`, user need to install via `snap --classic`.

This PR is pending for the merge of #316