### PR TITLE
fix: Bring back broken footer links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -159,31 +159,31 @@ const config = {
             footer: {
                 style: "dark",
                 links: [
-                    // {
-                    //     title: "Docs",
-                    //     items: [
-                    //         {
-                    //             label: "Introduction",
-                    //             to: "/docs/",
-                    //         },
-                    //         {
-                    //             label: "Installation",
-                    //             to: "/docs/installation",
-                    //         },
-                    //         {
-                    //             label: "How-to Guides",
-                    //             to: "/docs/how_to_guides/authentication",
-                    //         },
-                    //         {
-                    //             label: "ORAS Commands",
-                    //             to: "/docs/commands/use_oras_cli",
-                    //         },
-                    //         {
-                    //             label: "Client Libraries",
-                    //             to: "/docs/client_libraries/overview",
-                    //         },
-                    //     ],
-                    // },
+                    {
+                        title: "Docs",
+                        items: [
+                            {
+                                label: "Introduction",
+                                to: "/docs/",
+                            },
+                            {
+                                label: "Installation",
+                                to: "/docs/installation",
+                            },
+                            {
+                                label: "How-to Guides",
+                                to: "/docs/how_to_guides/authentication",
+                            },
+                            {
+                                label: "ORAS Commands",
+                                to: "/docs/commands/use_oras_cli",
+                            },
+                            {
+                                label: "Client Libraries",
+                                to: "/docs/client_libraries/overview",
+                            },
+                        ],
+                    },
                     {
                         title: "Community",
                         items: [


### PR DESCRIPTION
I'm not entirely sure why these were broken before. Some other fix must have fixed them.