### PR TITLE
chore: update client library list for versioned docs

### DIFF
--- a/versioned_docs/version-1.1/client_libraries/overview.mdx
+++ b/versioned_docs/version-1.1/client_libraries/overview.mdx
@@ -12,6 +12,7 @@ The following languages are currently supported:
 - [Go](./go.mdx)
 - [Python](https://oras-project.github.io/oras-py/getting_started/user-guide.html) 
 - [Rust](./rust.mdx) (in progress)
+- [C#](https://oras-project.github.io/oras-dotnet/api)
 
 ## Unified Experience
 

--- a/versioned_docs/version-1.2/client_libraries/overview.mdx
+++ b/versioned_docs/version-1.2/client_libraries/overview.mdx
@@ -12,6 +12,7 @@ The following languages are currently supported:
 - [Go](./go.mdx)
 - [Python](https://oras-project.github.io/oras-py/getting_started/user-guide.html) 
 - [Rust](./rust.mdx) (in progress)
+- [C#](https://oras-project.github.io/oras-dotnet/api)
 
 ## Unified Experience
 


### PR DESCRIPTION
Since it isn't clear right now what is going to be used for latest, I'd like to keep these synced up.