### PR TITLE
chore: Update command docs for 1.1 and 1.2

### DIFF
--- a/versioned_docs/version-1.1/commands/oras_attach.mdx
+++ b/versioned_docs/version-1.1/commands/oras_attach.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras attach
 sidebar_position: 10
+warning: Do NOT modify this generated file
 ---
 
 # oras attach

--- a/versioned_docs/version-1.1/commands/oras_cp.mdx
+++ b/versioned_docs/version-1.1/commands/oras_cp.mdx
@@ -1,14 +1,15 @@
 ---
-title: oras copy
+title: oras cp
 sidebar_position: 50
+warning: Do NOT modify this generated file
 ---
 
-# oras copy
+# oras cp
 
-Copy artifacts from one target to another.
+Copy artifacts from one target to another
 
 ```bash
-oras copy [flags] <from>{:<tag>|@<digest>} <to>[:<tag>[,<tag>][...]]
+oras cp [flags] <from>{:<tag>|@<digest>} <to>[:<tag>[,<tag>][...]]
 ```
 
 ## Examples
@@ -19,13 +20,13 @@ Copy an artifact between registries:
 oras cp localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 ```
 
-Download an artifact into an OCI layout folder:
+Download an artifact into an OCI image layout folder:
 
 ```bash
 oras cp --to-oci-layout localhost:5000/net-monitor:v1 ./downloaded:v1
 ```
 
-Upload an artifact from an OCI layout folder:
+Upload an artifact from an OCI image layout folder:
 
 ```bash
 oras cp --from-oci-layout ./to-upload:v1 localhost:5000/net-monitor:v1
@@ -46,8 +47,7 @@ oras cp -r localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 Copy an artifact and referrers using specific methods for the Referrers API:
 
 ```bash
-oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag \
-    localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
+oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag     localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1 
 ```
 
 Copy certain platform of an artifact:

--- a/versioned_docs/version-1.1/commands/oras_discover.mdx
+++ b/versioned_docs/version-1.1/commands/oras_discover.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras discover
-sidebar_position: 30
+sidebar_position: 60
+warning: Do NOT modify this generated file
 ---
 
 # oras discover

--- a/versioned_docs/version-1.1/commands/oras_help.mdx
+++ b/versioned_docs/version-1.1/commands/oras_help.mdx
@@ -1,0 +1,20 @@
+---
+title: oras help
+sidebar_position: 70
+warning: Do NOT modify this generated file
+---
+
+# oras help
+
+Help provides help for any command in the application.
+Simply type oras help [path to command] for full details.
+
+```bash
+oras help [command] [flags]
+```
+
+## Options
+
+```
+  -h, --help   help for help
+```

--- a/versioned_docs/version-1.1/commands/oras_login.mdx
+++ b/versioned_docs/version-1.1/commands/oras_login.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras login
-sidebar_position: 50
+sidebar_position: 80
+warning: Do NOT modify this generated file
 ---
 
 # oras login

--- a/versioned_docs/version-1.1/commands/oras_logout.mdx
+++ b/versioned_docs/version-1.1/commands/oras_logout.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras logout
-sidebar_position: 60
+sidebar_position: 90
+warning: Do NOT modify this generated file
 ---
 
 # oras logout

--- a/versioned_docs/version-1.1/commands/oras_pull.mdx
+++ b/versioned_docs/version-1.1/commands/oras_pull.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras pull
-sidebar_position: 70
+sidebar_position: 140
+warning: Do NOT modify this generated file
 ---
 
 # oras pull

--- a/versioned_docs/version-1.1/commands/oras_push.mdx
+++ b/versioned_docs/version-1.1/commands/oras_push.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras push
-sidebar_position: 80
+sidebar_position: 150
+warning: Do NOT modify this generated file
 ---
 
 # oras push

--- a/versioned_docs/version-1.1/commands/oras_tag.mdx
+++ b/versioned_docs/version-1.1/commands/oras_tag.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras tag
-sidebar_position: 90
+sidebar_position: 180
+warning: Do NOT modify this generated file
 ---
 
 # oras tag

--- a/versioned_docs/version-1.1/commands/oras_version.mdx
+++ b/versioned_docs/version-1.1/commands/oras_version.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras version
-sidebar_position: 100
+sidebar_position: 190
+warning: Do NOT modify this generated file
 ---
 
 # oras version

--- a/versioned_docs/version-1.1/how_to_guides/distributing_oci_layouts.mdx
+++ b/versioned_docs/version-1.1/how_to_guides/distributing_oci_layouts.mdx
@@ -74,7 +74,7 @@ tar -xf ./hello-world.tar -C hello-world
 
 ## Push the OCI Image to a Repository
 
-You may use [`oras copy`](../commands/oras_copy.mdx) to push the OCI Image from your local disk to a repository.
+You may use [`oras copy`](../commands/oras_cp.mdx) to push the OCI Image from your local disk to a repository.
 
 In the following example, we are pushing the image to a local registry like zot:
 

--- a/versioned_docs/version-1.2/commands/oras_attach.mdx
+++ b/versioned_docs/version-1.2/commands/oras_attach.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras attach
 sidebar_position: 10
+warning: Do NOT modify this generated file
 ---
 
 # oras attach
@@ -9,15 +10,27 @@ sidebar_position: 10
 ** This command is in preview and under development. **
 
 ```bash
-oras attach [flags] --artifact-type=<type> <name>{:<tag>|@<digest>} <file>[:<type>] [...]
+oras attach [flags] --artifact-type=<type> <name>{:<tag>|@<digest>} <file>[:<layer_media_type>] [...]
 ```
 
 ## Examples
 
-Attach file 'hi.txt' with type 'doc/example' to manifest 'hello:v1' in registry 'localhost:5000':
+Attach file 'hi.txt' with aritifact type 'doc/example' to manifest 'hello:v1' in registry 'localhost:5000':
 
 ```bash
 oras attach --artifact-type doc/example localhost:5000/hello:v1 hi.txt
+```
+
+Attach file 'hi.txt' to a specific artifact with platform 'linux/amd64' in multi-arch index 'hello:v1'
+
+```bash
+oras attach --artifact-type doc/example --platform linux/amd64 localhost:5000/hello:v1 hi.txt
+```
+
+Push file "hi.txt" with the custom layer media type 'application/vnd.me.hi':
+
+```bash
+oras attach --artifact-type doc/example localhost:5000/hello:v1 hi.txt:application/vnd.me.hi
 ```
 
 Attach file "hi.txt" using a specific method for the Referrers API:
@@ -60,24 +73,34 @@ oras attach --oci-layout --artifact-type doc/example layout-dir:v1 hi.txt
 ## Options
 
 ```
-  -a, --annotation stringArray                     manifest annotations
-      --annotation-file string                     path of the annotation file
-      --artifact-type string                       artifact type
-      --ca-file string                             server certificate authority file for the remote registry
-      --concurrency int                            concurrency level (default 5)
-  -d, --debug                                      debug mode
-      --disable-path-validation                    skip path validation
-      --distribution-spec string                   [Preview] set OCI distribution spec version and API option for target. options: v1.1-referrers-api, v1.1-referrers-tag
-      --export-manifest path                       path of the pushed manifest
-  -H, --header stringArray                         add custom headers to requests
-  -h, --help                                       help for attach
-      --insecure                                   allow connections to SSL registry without certs
-      --oci-layout                                 set target as an OCI image layout
-  -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
-      --plain-http                                 allow insecure connections to registry without SSL check
-      --registry-config path                       path of the authentication file for registry
-      --resolve host:port:address[:address_port]   customized DNS for registry, formatted in host:port:address[:address_port]
-  -u, --username string                            registry username
-  -v, --verbose                                    verbose output
+  -a, --annotation stringArray                      manifest annotations
+      --annotation-file string                      path of the annotation file
+      --artifact-type string                        artifact type
+      --ca-file string                              server certificate authority file for the remote registry
+      --cert-file string                            client certificate file for the remote registry
+      --concurrency int                             concurrency level (default 5)
+  -d, --debug                                       output debug logs (implies --no-tty)
+      --disable-path-validation                     skip path validation
+      --distribution-spec string                    [Preview] set OCI distribution spec version and API option for target. Options: v1.1-referrers-tag, v1.1-referrers-api
+      --export-manifest path                        path of the pushed manifest
+      --format string                               [Experimental] Format output using a custom template:
+                                                    'json':         Print in JSON format
+                                                    'go-template':  Print output using the given Go template
+  -H, --header stringArray                          add custom headers to requests
+  -h, --help                                        help for attach
+      --identity-token string                       registry identity token
+      --identity-token-stdin                        read identity token from stdin
+      --insecure                                    allow connections to SSL registry without certs
+      --key-file string                             client private key file for the remote registry
+      --no-tty                                      [Preview] do not show progress output
+      --oci-layout                                  set target as an OCI image layout
+  -p, --password string                             registry password or identity token
+      --password-stdin                              read password from stdin
+      --plain-http                                  allow insecure connections to registry without SSL check
+      --platform os[/arch][/variant][:os_version]   [Preview] attach to an arch-specific subject in the form of os[/arch][/variant][:os_version]
+      --registry-config path                        path of the authentication file for registry
+      --resolve host:port:address[:address_port]    customized DNS for registry, formatted in host:port:address[:address_port]
+      --template string                             [Experimental] Template string used to format output
+  -u, --username string                             registry username
+  -v, --verbose                                     verbose output
 ```

--- a/versioned_docs/version-1.2/commands/oras_cp.mdx
+++ b/versioned_docs/version-1.2/commands/oras_cp.mdx
@@ -1,14 +1,15 @@
 ---
-title: oras copy
+title: oras cp
 sidebar_position: 50
+warning: Do NOT modify this generated file
 ---
 
-# oras copy
+# oras cp
 
-Copy artifacts from one target to another.
+Copy artifacts from one target to another
 
 ```bash
-oras copy [flags] <from>{:<tag>|@<digest>} <to>[:<tag>[,<tag>][...]]
+oras cp [flags] <from>{:<tag>|@<digest>} <to>[:<tag>[,<tag>][...]]
 ```
 
 ## Examples
@@ -19,13 +20,13 @@ Copy an artifact between registries:
 oras cp localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 ```
 
-Download an artifact into an OCI layout folder:
+Download an artifact into an OCI image layout folder:
 
 ```bash
 oras cp --to-oci-layout localhost:5000/net-monitor:v1 ./downloaded:v1
 ```
 
-Upload an artifact from an OCI layout folder:
+Upload an artifact from an OCI image layout folder:
 
 ```bash
 oras cp --from-oci-layout ./to-upload:v1 localhost:5000/net-monitor:v1
@@ -46,8 +47,7 @@ oras cp -r localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 Copy an artifact and referrers using specific methods for the Referrers API:
 
 ```bash
-oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag \
-    localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
+oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag     localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 ```
 
 Copy certain platform of an artifact:
@@ -72,11 +72,14 @@ oras cp --concurrency 10 localhost:5000/net-monitor:v1 localhost:5000/net-monito
 
 ```
       --concurrency int                                 concurrency level (default 3)
-  -d, --debug                                           debug mode
+  -d, --debug                                           output debug logs (implies --no-tty)
       --from-ca-file string                             server certificate authority file for the remote source registry
-      --from-distribution-spec string                   [Preview] set OCI distribution spec version and API option for source target. options: v1.1-referrers-api, v1.1-referrers-tag
+      --from-cert-file string                           client certificate file for the remote source registry
+      --from-distribution-spec string                   [Preview] set OCI distribution spec version and API option for source target. Options: v1.1-referrers-tag, v1.1-referrers-api
       --from-header stringArray                         add custom headers to source requests
+      --from-identity-token string                      source registry identity token
       --from-insecure                                   allow connections to source SSL registry without certs
+      --from-key-file string                            client private key file for the remote source registry
       --from-oci-layout                                 set source target as an OCI image layout
       --from-password string                            source registry password or identity token
       --from-plain-http                                 allow insecure connections to source registry without SSL check
@@ -84,13 +87,17 @@ oras cp --concurrency 10 localhost:5000/net-monitor:v1 localhost:5000/net-monito
       --from-resolve host:port:address[:address_port]   customized DNS for source registry, formatted in host:port:address[:address_port]
       --from-username string                            source registry username
   -h, --help                                            help for cp
+      --no-tty                                          [Preview] do not show progress output
       --platform os[/arch][/variant][:os_version]       request platform in the form of os[/arch][/variant][:os_version]
   -r, --recursive                                       [Preview] recursively copy the artifact and its referrer artifacts
       --resolve host:port:address[:address_port]        base DNS rules formatted in host:port:address[:address_port] for --from-resolve and --to-resolve
       --to-ca-file string                               server certificate authority file for the remote destination registry
-      --to-distribution-spec string                     [Preview] set OCI distribution spec version and API option for destination target. options: v1.1-referrers-api, v1.1-referrers-tag
+      --to-cert-file string                             client certificate file for the remote destination registry
+      --to-distribution-spec string                     [Preview] set OCI distribution spec version and API option for destination target. Options: v1.1-referrers-tag, v1.1-referrers-api
       --to-header stringArray                           add custom headers to destination requests
+      --to-identity-token string                        destination registry identity token
       --to-insecure                                     allow connections to destination SSL registry without certs
+      --to-key-file string                              client private key file for the remote destination registry
       --to-oci-layout                                   set destination target as an OCI image layout
       --to-password string                              destination registry password or identity token
       --to-plain-http                                   allow insecure connections to destination registry without SSL check

--- a/versioned_docs/version-1.2/commands/oras_discover.mdx
+++ b/versioned_docs/version-1.2/commands/oras_discover.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras discover
-sidebar_position: 30
+sidebar_position: 60
+warning: Do NOT modify this generated file
 ---
 
 # oras discover
@@ -62,19 +63,30 @@ oras discover --oci-layout -v -o tree layout-dir:v1
 ```
       --artifact-type string                        artifact type
       --ca-file string                              server certificate authority file for the remote registry
-  -d, --debug                                       debug mode
-      --distribution-spec string                    [Preview] set OCI distribution spec version and API option for target. options: v1.1-referrers-api, v1.1-referrers-tag
+      --cert-file string                            client certificate file for the remote registry
+  -d, --debug                                       output debug logs (implies --no-tty)
+      --distribution-spec string                    [Preview] set OCI distribution spec version and API option for target. Options: v1.1-referrers-tag, v1.1-referrers-api
+      --format string                               [Experimental] Format output using a custom template:
+                                                    'tree':         Get referrers recursively and print in tree format
+                                                    'table':        Get direct referrers and output in table format
+                                                    'json':         Get direct referrers and output in JSON format
+                                                    'go-template':  Print direct referrers using the given Go template (default "tree")
   -H, --header stringArray                          add custom headers to requests
   -h, --help                                        help for discover
+      --identity-token string                       registry identity token
+      --identity-token-stdin                        read identity token from stdin
       --insecure                                    allow connections to SSL registry without certs
+      --key-file string                             client private key file for the remote registry
+      --no-tty                                      [Preview] do not show progress output
       --oci-layout                                  set target as an OCI image layout
-  -o, --output string                               format in which to display referrers (table, json, or tree). tree format will also show indirect referrers (default "table")
+  -o, --output string                               [Deprecated] format in which to display referrers (table, json, or tree). tree format will also show indirect referrers (default "tree")
   -p, --password string                             registry password or identity token
-      --password-stdin                              read password or identity token from stdin
+      --password-stdin                              read password from stdin
       --plain-http                                  allow insecure connections to registry without SSL check
       --platform os[/arch][/variant][:os_version]   request platform in the form of os[/arch][/variant][:os_version]
       --registry-config path                        path of the authentication file for registry
       --resolve host:port:address[:address_port]    customized DNS for registry, formatted in host:port:address[:address_port]
+      --template string                             [Experimental] Template string used to format output
   -u, --username string                             registry username
   -v, --verbose                                     verbose output
 ```

--- a/versioned_docs/version-1.2/commands/oras_help.mdx
+++ b/versioned_docs/version-1.2/commands/oras_help.mdx
@@ -1,0 +1,20 @@
+---
+title: oras help
+sidebar_position: 70
+warning: Do NOT modify this generated file
+---
+
+# oras help
+
+Help provides help for any command in the application.
+Simply type oras help [path to command] for full details.
+
+```bash
+oras help [command] [flags]
+```
+
+## Options
+
+```
+  -h, --help   help for help
+```

--- a/versioned_docs/version-1.2/commands/oras_login.mdx
+++ b/versioned_docs/version-1.2/commands/oras_login.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras login
-sidebar_position: 50
+sidebar_position: 80
+warning: Do NOT modify this generated file
 ---
 
 # oras login
@@ -28,13 +29,13 @@ oras login -u username --password-stdin localhost:5000
 Log in with identity token from command line flags:
 
 ```bash
-oras login -p token localhost:5000
+oras login --identity-token token localhost:5000
 ```
 
 Log in with identity token from stdin:
 
 ```bash
-oras login --password-stdin localhost:5000
+oras login --identity-token-stdin localhost:5000
 ```
 
 Log in with username and password in an interactive terminal:
@@ -53,12 +54,17 @@ oras login --insecure localhost:5000
 
 ```
       --ca-file string                             server certificate authority file for the remote registry
-  -d, --debug                                      debug mode
+      --cert-file string                           client certificate file for the remote registry
+  -d, --debug                                      output debug logs (implies --no-tty)
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for login
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
+      --no-tty                                     [Preview] do not show progress output
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --registry-config path                       path of the authentication file for registry
       --resolve host:port:address[:address_port]   customized DNS for registry, formatted in host:port:address[:address_port]

--- a/versioned_docs/version-1.2/commands/oras_logout.mdx
+++ b/versioned_docs/version-1.2/commands/oras_logout.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras logout
-sidebar_position: 60
+sidebar_position: 90
+warning: Do NOT modify this generated file
 ---
 
 # oras logout

--- a/versioned_docs/version-1.2/commands/oras_pull.mdx
+++ b/versioned_docs/version-1.2/commands/oras_pull.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras pull
-sidebar_position: 70
+sidebar_position: 140
+warning: Do NOT modify this generated file
 ---
 
 # oras pull
@@ -73,22 +74,31 @@ oras pull --oci-layout layout.tar:v1
 ```
   -T, --allow-path-traversal                        allow storing files out of the output directory
       --ca-file string                              server certificate authority file for the remote registry
+      --cert-file string                            client certificate file for the remote registry
       --concurrency int                             concurrency level (default 3)
       --config string                               output manifest config file
-  -d, --debug                                       debug mode
+  -d, --debug                                       output debug logs (implies --no-tty)
+      --format string                               [Experimental] Format output using a custom template:
+                                                    'json':         Print in JSON format
+                                                    'go-template':  Print output using the given Go template
   -H, --header stringArray                          add custom headers to requests
   -h, --help                                        help for pull
+      --identity-token string                       registry identity token
+      --identity-token-stdin                        read identity token from stdin
       --include-subject                             [Preview] recursively pull the subject of artifacts
       --insecure                                    allow connections to SSL registry without certs
   -k, --keep-old-files                              do not replace existing files when pulling, treat them as errors
+      --key-file string                             client private key file for the remote registry
+      --no-tty                                      [Preview] do not show progress output
       --oci-layout                                  set target as an OCI image layout
   -o, --output string                               output directory (default ".")
   -p, --password string                             registry password or identity token
-      --password-stdin                              read password or identity token from stdin
+      --password-stdin                              read password from stdin
       --plain-http                                  allow insecure connections to registry without SSL check
       --platform os[/arch][/variant][:os_version]   request platform in the form of os[/arch][/variant][:os_version]
       --registry-config path                        path of the authentication file for registry
       --resolve host:port:address[:address_port]    customized DNS for registry, formatted in host:port:address[:address_port]
+      --template string                             [Experimental] Template string used to format output
   -u, --username string                             registry username
   -v, --verbose                                     verbose output
 ```

--- a/versioned_docs/version-1.2/commands/oras_push.mdx
+++ b/versioned_docs/version-1.2/commands/oras_push.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras push
-sidebar_position: 80
+sidebar_position: 150
+warning: Do NOT modify this generated file
 ---
 
 # oras push
@@ -104,21 +105,30 @@ oras push --oci-layout layout-dir:test hi.txt
       --annotation-file string                     path of the annotation file
       --artifact-type string                       artifact type
       --ca-file string                             server certificate authority file for the remote registry
+      --cert-file string                           client certificate file for the remote registry
       --concurrency int                            concurrency level (default 5)
       --config path                                path of image config file
-  -d, --debug                                      debug mode
+  -d, --debug                                      output debug logs (implies --no-tty)
       --disable-path-validation                    skip path validation
       --export-manifest path                       path of the pushed manifest
+      --format string                              [Experimental] Format output using a custom template:
+                                                   'json':         Print in JSON format
+                                                   'go-template':  Print output using the given Go template
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for push
-      --image-spec string                          [Experimental] specify manifest type for building artifact. options: v1.1, v1.0 (default "v1.1")
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
+      --image-spec string                          [Preview] specify manifest type for building artifact. Options: v1.1, v1.0 (default v1.1, overridden to v1.0 if --config is used without --artifact-type)
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
+      --no-tty                                     [Preview] do not show progress output
       --oci-layout                                 set target as an OCI image layout
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --registry-config path                       path of the authentication file for registry
       --resolve host:port:address[:address_port]   customized DNS for registry, formatted in host:port:address[:address_port]
+      --template string                            [Experimental] Template string used to format output
   -u, --username string                            registry username
   -v, --verbose                                    verbose output
 ```

--- a/versioned_docs/version-1.2/commands/oras_resolve.mdx
+++ b/versioned_docs/version-1.2/commands/oras_resolve.mdx
@@ -1,0 +1,46 @@
+---
+title: oras resolve
+sidebar_position: 180
+warning: Do NOT modify this generated file
+---
+
+# oras resolve
+
+[Experimental] Resolves digest of the target artifact
+
+```bash
+oras resolve [flags] <name>{:<tag>|@<digest>}
+```
+
+## Examples
+
+Resolve digest of the target artifact:
+
+```bash
+oras resolve localhost:5000/hello-world:v1
+```
+
+## Options
+
+```
+      --ca-file string                              server certificate authority file for the remote registry
+      --cert-file string                            client certificate file for the remote registry
+  -d, --debug                                       output debug logs (implies --no-tty)
+  -l, --full-reference                              print the full artifact reference with digest
+  -H, --header stringArray                          add custom headers to requests
+  -h, --help                                        help for resolve
+      --identity-token string                       registry identity token
+      --identity-token-stdin                        read identity token from stdin
+      --insecure                                    allow connections to SSL registry without certs
+      --key-file string                             client private key file for the remote registry
+      --no-tty                                      [Preview] do not show progress output
+      --oci-layout                                  set target as an OCI image layout
+  -p, --password string                             registry password or identity token
+      --password-stdin                              read password from stdin
+      --plain-http                                  allow insecure connections to registry without SSL check
+      --platform os[/arch][/variant][:os_version]   request platform in the form of os[/arch][/variant][:os_version]
+      --registry-config path                        path of the authentication file for registry
+      --resolve host:port:address[:address_port]    customized DNS for registry, formatted in host:port:address[:address_port]
+  -u, --username string                             registry username
+  -v, --verbose                                     verbose output
+```

--- a/versioned_docs/version-1.2/commands/oras_tag.mdx
+++ b/versioned_docs/version-1.2/commands/oras_tag.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras tag
-sidebar_position: 90
+sidebar_position: 190
+warning: Do NOT modify this generated file
 ---
 
 # oras tag
@@ -47,14 +48,19 @@ oras tag layout-dir:v1.0.1 v1.0.2
 
 ```
       --ca-file string                             server certificate authority file for the remote registry
+      --cert-file string                           client certificate file for the remote registry
       --concurrency int                            concurrency level (default 5)
-  -d, --debug                                      debug mode
+  -d, --debug                                      output debug logs (implies --no-tty)
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for tag
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
+      --no-tty                                     [Preview] do not show progress output
       --oci-layout                                 set target as an OCI image layout
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --registry-config path                       path of the authentication file for registry
       --resolve host:port:address[:address_port]   customized DNS for registry, formatted in host:port:address[:address_port]

--- a/versioned_docs/version-1.2/commands/oras_version.mdx
+++ b/versioned_docs/version-1.2/commands/oras_version.mdx
@@ -1,6 +1,7 @@
 ---
 title: oras version
-sidebar_position: 100
+sidebar_position: 200
+warning: Do NOT modify this generated file
 ---
 
 # oras version

--- a/versioned_docs/version-1.2/how_to_guides/distributing_oci_layouts.mdx
+++ b/versioned_docs/version-1.2/how_to_guides/distributing_oci_layouts.mdx
@@ -74,7 +74,7 @@ tar -xf ./hello-world.tar -C hello-world
 
 ## Push the OCI Image to a Repository
 
-You may use [`oras copy`](../commands/oras_copy.mdx) to push the OCI Image from your local disk to a repository.
+You may use [`oras copy`](../commands/oras_cp.mdx) to push the OCI Image from your local disk to a repository.
 
 In the following example, we are pushing the image to a local registry like zot:
 


### PR DESCRIPTION
Just ran the refresh script for 1.1 and 1.2. This is the same change that was merged in https://github.com/oras-project/oras-www/pull/319 but it is for 1.1 and 1.2.

Closes: https://github.com/oras-project/oras-www/issues/350