### PR TITLE
Preserve backslash

### DIFF
--- a/tools/parse.sh
+++ b/tools/parse.sh
@@ -27,7 +27,7 @@ STATE=Introduction
 EXAMPLES=""
 PREFIX="Example - "
 >${EXAMPLES_FILE}
-cat ${TEMPFILE} | while read LINE
+cat ${TEMPFILE} | while read -r LINE
 do
     [[ "${LINE}" == "" ]] && continue
     if [[ "${LINE}" == Aliases* ]]

--- a/versioned_docs/version-1.1/commands/oras_cp.mdx
+++ b/versioned_docs/version-1.1/commands/oras_cp.mdx
@@ -47,7 +47,8 @@ oras cp -r localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 Copy an artifact and referrers using specific methods for the Referrers API:
 
 ```bash
-oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag     localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1 
+oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag \
+localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1 
 ```
 
 Copy certain platform of an artifact:

--- a/versioned_docs/version-1.2/commands/oras_cp.mdx
+++ b/versioned_docs/version-1.2/commands/oras_cp.mdx
@@ -47,7 +47,8 @@ oras cp -r localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 Copy an artifact and referrers using specific methods for the Referrers API:
 
 ```bash
-oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag     localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
+oras cp -r --from-distribution-spec v1.1-referrers-api --to-distribution-spec v1.1-referrers-tag \
+localhost:5000/net-monitor:v1 localhost:6000/net-monitor-copy:v1
 ```
 
 Copy certain platform of an artifact:


### PR DESCRIPTION
Adding this argument to the read will preserve the `\` for the oras_copy documentation.  Another PR contains the documentation updates. The change results in this:

![Screenshot 2024-06-23 at 1 32 53 PM](https://github.com/oras-project/oras-www/assets/104113/7e7a2882-acb0-4ded-8b88-d163c5419b14)
