### PR TITLE
fix: Subcommand generation was broken for versioned docs

### DIFF
--- a/tools/refresh-commands.sh
+++ b/tools/refresh-commands.sh
@@ -59,14 +59,16 @@ do
     LATEST_VERSION=$(map_version $VERSION)
     ORAS_COMMAND=$(./tools/install.sh ${LATEST_VERSION} ${TEMPDIR})
     WEIGHT=10
+    VERSIONED_DOCS=versioned_docs/version-${VERSION}/commands
     list_commands >"${TEMPDIR}/commands"
     while read COMMAND
     do
-        list_commands >"${TEMPDIR}/subcommands"
-        if [ -s "${TEMPDIR}/subcommands" ]
+        list_commands "${COMMAND}" >"${TEMPDIR}/subcommands"
+        if [ ! -s "${TEMPDIR}/subcommands" ]
         then
-            ./tools/parse.sh ${TEMPDIR} "${COMMAND}" $WEIGHT >versioned_docs/version-${VERSION}/commands/oras_$COMMAND.mdx
-            if git diff versioned_docs/version-${VERSION}/commands/oras_$COMMAND.mdx >/dev/null
+            FILE="${VERSIONED_DOCS}/oras_${COMMAND}.mdx"
+            ./tools/parse.sh ${TEMPDIR} "${COMMAND}" $WEIGHT >"${FILE}"
+            if git diff "${FILE}" >/dev/null
             then
                 DIFFS=true
             fi
@@ -74,8 +76,7 @@ do
         else
             while read SUBCOMMAND
             do
-                FILE="docs/commands/oras_${COMMAND}_${SUBCOMMAND}.mdx"
-                echo $FILE
+                FILE="${VERSIONED_DOCS}/oras_${COMMAND}_${SUBCOMMAND}.mdx"
                 ./tools/parse.sh ${TEMPDIR} "${COMMAND} ${SUBCOMMAND}" $WEIGHT >"${FILE}"
                 if git diff "${FILE}" >/dev/null
                 then

--- a/versioned_docs/version-1.1/commands/oras_blob_delete.mdx
+++ b/versioned_docs/version-1.1/commands/oras_blob_delete.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras blob delete
 sidebar_position: 20
+warning: Do NOT modify this generated file
 ---
 
 # oras blob delete
 
-Delete a blob from a remote registry.
+Delete a blob from a remote registry
 
 ```bash
 oras blob delete [flags] <name>@<digest>
@@ -22,14 +23,14 @@ oras blob delete localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be
 Delete a blob without prompting confirmation:
 
 ```bash
-oras blob delete --yes localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
+oras blob delete --force localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
 ```
 
 Delete a blob and print its descriptor:
 
 ```bash
-oras blob delete --descriptor --yes localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
-```  
+oras blob delete --descriptor --force localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
+```
 
 ## Options
 
@@ -50,4 +51,3 @@ oras blob delete --descriptor --yes localhost:5000/hello@sha256:9a201d228ebd9662
   -u, --username string                            registry username
   -v, --verbose                                    verbose output
 ```
-

--- a/versioned_docs/version-1.1/commands/oras_blob_fetch.mdx
+++ b/versioned_docs/version-1.1/commands/oras_blob_fetch.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras blob fetch
 sidebar_position: 30
+warning: Do NOT modify this generated file
 ---
 
 # oras blob fetch
 
-Fetch a blob from a remote registry.
+Fetch a blob from a registry or an OCI image layout
 
 ```bash
 oras blob fetch [flags] {--output <file> | --descriptor} <name>@<digest>
@@ -47,14 +48,6 @@ Fetch and print a blob from OCI image layout archive file 'layout.tar':
 
 ```bash
 oras blob fetch --oci-layout --output - layout.tar@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
-```
-
-Fetch a blob with a specific reference, determine its size using `jq`, and use `pv` to display the progress while redirecting the output to a file named `layer.bin`:
-
-```bash
- $blob_ref=ghcr.io/oras-project/oras@sha256:74529e03eae02d1fff5c05e9a6ec2089e1f5ae96421169c29a7c165346e042e4
- $size=$(oras blob fetch --descriptor $blob_ref | jq -r .size)
- $oras blob fetch $blob_ref --output - | pv -s $size > layer.bin
 ```
 
 ## Options

--- a/versioned_docs/version-1.1/commands/oras_blob_push.mdx
+++ b/versioned_docs/version-1.1/commands/oras_blob_push.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras blob push
 sidebar_position: 40
+warning: Do NOT modify this generated file
 ---
 
 # oras blob push
 
-Push a blob to a remote registry.
+Push a blob to a registry or an OCI image layout
 
 ```bash
 oras blob push [flags] <name>[@digest] <file>
@@ -13,13 +14,13 @@ oras blob push [flags] <name>[@digest] <file>
 
 ## Examples
 
-Push blob "hi.txt":
+Push blob 'hi.txt' to a registry:
 
 ```bash
 oras blob push localhost:5000/hello hi.txt
 ```
 
-Push blob "hi.txt" with the specific digest:
+Push blob 'hi.txt' with the specific digest:
 
 ```bash
 oras blob push localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5 hi.txt
@@ -31,19 +32,19 @@ Push blob from stdin with blob size and digest:
 oras blob push --size 12 localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5 -
 ```
 
-Push blob "hi.txt" and output the descriptor:
+Push blob 'hi.txt' and output the descriptor:
 
 ```bash
 oras blob push --descriptor localhost:5000/hello hi.txt
 ```
 
-Push blob "hi.txt" with the specific returned media type in the descriptor:
+Push blob 'hi.txt' with the specific returned media type in the descriptor:
 
 ```bash
 oras blob push --media-type application/vnd.oci.image.config.v1+json --descriptor localhost:5000/hello hi.txt
 ```
 
-Push blob "hi.txt" and output the prettified descriptor:
+Push blob 'hi.txt' and output the prettified descriptor:
 
 ```bash
 oras blob push --descriptor --pretty localhost:5000/hello hi.txt
@@ -55,7 +56,7 @@ Push blob without TLS:
 oras blob push --insecure localhost:5000/hello hi.txt
 ```
 
-Push blob 'hi.txt' into an OCI layout folder 'layout-dir':
+Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 
 ```bash
 oras blob push --oci-layout layout-dir hi.txt

--- a/versioned_docs/version-1.1/commands/oras_manifest_delete.mdx
+++ b/versioned_docs/version-1.1/commands/oras_manifest_delete.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras manifest delete
-sidebar_position: 90
+sidebar_position: 100
+warning: Do NOT modify this generated file
 ---
 
 # oras manifest delete
 
-Delete a manifest from remote registry.
+Delete a manifest from remote registry
 
 ```bash
 oras manifest delete [flags] <name>{:<tag>|@<digest>}
@@ -16,25 +17,25 @@ oras manifest delete [flags] <name>{:<tag>|@<digest>}
 Delete a manifest tagged with 'v1' from repository 'localhost:5000/hello':
 
 ```bash
-  oras manifest delete localhost:5000/hello:v1
+oras manifest delete localhost:5000/hello:v1
 ```
 
 Delete a manifest without prompting confirmation:
 
 ```bash
-  oras manifest delete --force localhost:5000/hello:v1
+oras manifest delete --force localhost:5000/hello:v1
 ```
 
 Delete a manifest and print its descriptor:
 
 ```bash
-  oras manifest delete --descriptor localhost:5000/hello:v1
+oras manifest delete --descriptor localhost:5000/hello:v1
 ```
 
 Delete a manifest by digest 'sha256:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9' from repository 'localhost:5000/hello':
 
 ```bash
-  oras manifest delete localhost:5000/hello@sha:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
+oras manifest delete localhost:5000/hello@sha:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
 ```
 
 ## Options

--- a/versioned_docs/version-1.1/commands/oras_manifest_fetch-config.mdx
+++ b/versioned_docs/version-1.1/commands/oras_manifest_fetch-config.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras manifest fetch-config
-sidebar_position: 100
+sidebar_position: 120
+warning: Do NOT modify this generated file
 ---
 
 # oras manifest fetch-config
 
-Fetch the config of a manifest from a remote registry.
+Fetch the config of a manifest from a registry or an OCI image layout
 
 ```bash
 oras manifest fetch-config [flags] <name>{:<tag>|@<digest>}
@@ -49,7 +50,6 @@ Fetch and print the prettified descriptor of the config:
 oras manifest fetch-config --descriptor --pretty localhost:5000/hello:v1
 ```
 
-
 ## Options
 
 ```
@@ -57,11 +57,10 @@ oras manifest fetch-config --descriptor --pretty localhost:5000/hello:v1
   -d, --debug                                       debug mode
       --descriptor                                  output the descriptor
   -H, --header stringArray                          add custom headers to requests
-  -h, --help                                        help for fetch
+  -h, --help                                        help for fetch-config
       --insecure                                    allow connections to SSL registry without certs
-      --media-type strings                          accepted media types
       --oci-layout                                  set target as an OCI image layout
-  -o, --output path                                 file path to write the fetched manifest to, use - for stdout
+  -o, --output path                                 file path to write the fetched config to, use - for stdout
   -p, --password string                             registry password or identity token
       --password-stdin                              read password or identity token from stdin
       --plain-http                                  allow insecure connections to registry without SSL check

--- a/versioned_docs/version-1.1/commands/oras_manifest_fetch.mdx
+++ b/versioned_docs/version-1.1/commands/oras_manifest_fetch.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras manifest fetch
 sidebar_position: 110
+warning: Do NOT modify this generated file
 ---
 
 # oras manifest fetch
 
-Fetch manifest of the target artifact.
+Fetch manifest of the target artifact
 
 ```bash
 oras manifest fetch [flags] <name>{:<tag>|@<digest>}
@@ -43,7 +44,7 @@ Fetch manifest from a registry with prettified json result:
 oras manifest fetch --pretty localhost:5000/hello:v1
 ```
 
-Fetch raw manifest from an OCI layout folder 'layout-dir':
+Fetch raw manifest from an OCI image layout folder 'layout-dir':
 
 ```bash
 oras manifest fetch --oci-layout layout-dir:v1
@@ -61,18 +62,19 @@ oras manifest fetch --oci-layout layout.tar:v1
       --ca-file string                              server certificate authority file for the remote registry
   -d, --debug                                       debug mode
       --descriptor                                  output the descriptor
+  -H, --header stringArray                          add custom headers to requests
   -h, --help                                        help for fetch
       --insecure                                    allow connections to SSL registry without certs
       --media-type strings                          accepted media types
-      --oci-layout                                  set target as an OCI image layout.
+      --oci-layout                                  set target as an OCI image layout
   -o, --output path                                 file path to write the fetched manifest to, use - for stdout
   -p, --password string                             registry password or identity token
       --password-stdin                              read password or identity token from stdin
       --plain-http                                  allow insecure connections to registry without SSL check
       --platform os[/arch][/variant][:os_version]   request platform in the form of os[/arch][/variant][:os_version]
       --pretty                                      prettify JSON objects printed to stdout
-      --registry-config path                        path of the authentication file
-      --resolve host:port:address                   customized DNS formatted in host:port:address
+      --registry-config path                        path of the authentication file for registry
+      --resolve host:port:address[:address_port]    customized DNS for registry, formatted in host:port:address[:address_port]
   -u, --username string                             registry username
   -v, --verbose                                     verbose output
 ```

--- a/versioned_docs/version-1.1/commands/oras_manifest_push.mdx
+++ b/versioned_docs/version-1.1/commands/oras_manifest_push.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras manifest push
-sidebar_position: 120
+sidebar_position: 130
+warning: Do NOT modify this generated file
 ---
 
 # oras manifest push
 
-Push a manifest to remote registry.
+Push a manifest to a registry or an OCI image layout
 
 ```bash
 oras manifest push [flags] <name>[:<tag>[,<tag>][...]|@<digest>] <file>
@@ -62,7 +63,7 @@ Push a manifest to repository 'localhost:5000/hello' and tag with 'tag1', 'tag2'
 oras manifest push --concurrency 6 localhost:5000/hello:tag1,tag2,tag3 manifest.json
 ```
 
-Push a manifest to an OCI layout folder 'layout-dir' and tag with 'v1':
+Push a manifest to an OCI image layout folder 'layout-dir' and tag with 'v1':
 
 ```bash
 oras manifest push --oci-layout layout-dir:v1 manifest.json

--- a/versioned_docs/version-1.1/commands/oras_repo_ls.mdx
+++ b/versioned_docs/version-1.1/commands/oras_repo_ls.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras repo ls
-sidebar_position: 150
+sidebar_position: 160
+warning: Do NOT modify this generated file
 ---
 
 # oras repo ls
 
-List the repositories under the registry.
+List the repositories under the registry
 
 ```bash
 oras repo ls [flags] <registry>
@@ -13,19 +14,19 @@ oras repo ls [flags] <registry>
 
 ## Examples
 
-Example - List the repositories under the registry:
+List the repositories under the registry:
 
 ```bash
 oras repo ls localhost:5000
 ```
 
-Example - List the repositories under a namespace in the registry:
+List the repositories under a namespace in the registry:
 
 ```bash
 oras repo ls localhost:5000/example-namespace
 ```
 
-Example - List the repositories under the registry that include values lexically after last:
+List the repositories under the registry that include values lexically after last:
 
 ```bash
 oras repo ls --last "last_repo" localhost:5000
@@ -33,7 +34,7 @@ oras repo ls --last "last_repo" localhost:5000
 
 ## Options
 
-```bash
+```
       --ca-file string                             server certificate authority file for the remote registry
   -d, --debug                                      debug mode
   -H, --header stringArray                         add custom headers to requests

--- a/versioned_docs/version-1.1/commands/oras_repo_tags.mdx
+++ b/versioned_docs/version-1.1/commands/oras_repo_tags.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras repo tags
-sidebar_position: 160
+sidebar_position: 170
+warning: Do NOT modify this generated file
 ---
 
 # oras repo tags
 
-Show tags of the target repository.
+Show tags of the target repository
 
 ```bash
 oras repo tags [flags] <name>
@@ -31,7 +32,7 @@ Show tags of the target repository that include values lexically after last:
 oras repo tags --last "last_tag" localhost:5000/hello
 ```
 
-Show tags of the target OCI layout folder 'layout-dir':
+Show tags of the target OCI image layout folder 'layout-dir':
 
 ```bash
 oras repo tags --oci-layout layout-dir
@@ -43,13 +44,13 @@ Show tags of the target OCI layout archive 'layout.tar':
 oras repo tags --oci-layout layout.tar
 ```
 
-Show tags associated with a particular tagged resource:
+[Experimental] Show tags associated with a particular tagged resource:
 
 ```bash
 oras repo tags localhost:5000/hello:latest
 ```
 
-Show tags associated with a digest:
+[Experimental] Show tags associated with a digest:
 
 ```bash
 oras repo tags localhost:5000/hello@sha256:c551125a624189cece9135981621f3f3144564ddabe14b523507bf74c2281d9b

--- a/versioned_docs/version-1.2/commands/oras_blob_delete.mdx
+++ b/versioned_docs/version-1.2/commands/oras_blob_delete.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras blob delete
 sidebar_position: 20
+warning: Do NOT modify this generated file
 ---
 
 # oras blob delete
 
-Delete a blob from a remote registry.
+Delete a blob from a remote registry
 
 ```bash
 oras blob delete [flags] <name>@<digest>
@@ -22,27 +23,33 @@ oras blob delete localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be
 Delete a blob without prompting confirmation:
 
 ```bash
-oras blob delete --yes localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
+oras blob delete --force localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
 ```
 
 Delete a blob and print its descriptor:
 
 ```bash
-oras blob delete --descriptor --yes localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
-```  
+oras blob delete --descriptor --force localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
+```
 
 ## Options
 
 ```
       --ca-file string                             server certificate authority file for the remote registry
-  -d, --debug                                      debug mode
+      --cert-file string                           client certificate file for the remote registry
+  -d, --debug                                      output debug logs (implies --no-tty)
       --descriptor                                 output the descriptor
   -f, --force                                      ignore nonexistent references, never prompt
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for delete
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
+      --no-tty                                     [Preview] do not show progress output
+      --oci-layout                                 set target as an OCI image layout
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --pretty                                     prettify JSON objects printed to stdout
       --registry-config path                       path of the authentication file for registry
@@ -50,4 +57,3 @@ oras blob delete --descriptor --yes localhost:5000/hello@sha256:9a201d228ebd9662
   -u, --username string                            registry username
   -v, --verbose                                    verbose output
 ```
-

--- a/versioned_docs/version-1.2/commands/oras_blob_fetch.mdx
+++ b/versioned_docs/version-1.2/commands/oras_blob_fetch.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras blob fetch
 sidebar_position: 30
+warning: Do NOT modify this generated file
 ---
 
 # oras blob fetch
 
-Fetch a blob from a remote registry.
+Fetch a blob from a registry or an OCI image layout
 
 ```bash
 oras blob fetch [flags] {--output <file> | --descriptor} <name>@<digest>
@@ -49,27 +50,24 @@ Fetch and print a blob from OCI image layout archive file 'layout.tar':
 oras blob fetch --oci-layout --output - layout.tar@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5
 ```
 
-Fetch a blob with a specific reference, determine its size using `jq`, and use `pv` to display the progress while redirecting the output to a file named `layer.bin`:
-
-```bash
- $blob_ref=ghcr.io/oras-project/oras@sha256:74529e03eae02d1fff5c05e9a6ec2089e1f5ae96421169c29a7c165346e042e4
- $size=$(oras blob fetch --descriptor $blob_ref | jq -r .size)
- $oras blob fetch $blob_ref --output - | pv -s $size > layer.bin
-```
-
 ## Options
 
 ```
       --ca-file string                             server certificate authority file for the remote registry
-  -d, --debug                                      debug mode
+      --cert-file string                           client certificate file for the remote registry
+  -d, --debug                                      output debug logs (implies --no-tty)
       --descriptor                                 output the descriptor
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for fetch
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
+      --no-tty                                     [Preview] do not show progress output
       --oci-layout                                 set target as an OCI image layout
   -o, --output path                                output file path, use - for stdout
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --pretty                                     prettify JSON objects printed to stdout
       --registry-config path                       path of the authentication file for registry

--- a/versioned_docs/version-1.2/commands/oras_blob_push.mdx
+++ b/versioned_docs/version-1.2/commands/oras_blob_push.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras blob push
 sidebar_position: 40
+warning: Do NOT modify this generated file
 ---
 
 # oras blob push
 
-Push a blob to a remote registry.
+Push a blob to a registry or an OCI image layout
 
 ```bash
 oras blob push [flags] <name>[@digest] <file>
@@ -13,13 +14,13 @@ oras blob push [flags] <name>[@digest] <file>
 
 ## Examples
 
-Push blob "hi.txt":
+Push blob 'hi.txt' to a registry:
 
 ```bash
 oras blob push localhost:5000/hello hi.txt
 ```
 
-Push blob "hi.txt" with the specific digest:
+Push blob 'hi.txt' with the specific digest:
 
 ```bash
 oras blob push localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5 hi.txt
@@ -31,19 +32,19 @@ Push blob from stdin with blob size and digest:
 oras blob push --size 12 localhost:5000/hello@sha256:9a201d228ebd966211f7d1131be19f152be428bd373a92071c71d8deaf83b3e5 -
 ```
 
-Push blob "hi.txt" and output the descriptor:
+Push blob 'hi.txt' and output the descriptor:
 
 ```bash
 oras blob push --descriptor localhost:5000/hello hi.txt
 ```
 
-Push blob "hi.txt" with the specific returned media type in the descriptor:
+Push blob 'hi.txt' with the specific returned media type in the descriptor:
 
 ```bash
 oras blob push --media-type application/vnd.oci.image.config.v1+json --descriptor localhost:5000/hello hi.txt
 ```
 
-Push blob "hi.txt" and output the prettified descriptor:
+Push blob 'hi.txt' and output the prettified descriptor:
 
 ```bash
 oras blob push --descriptor --pretty localhost:5000/hello hi.txt
@@ -55,7 +56,7 @@ Push blob without TLS:
 oras blob push --insecure localhost:5000/hello hi.txt
 ```
 
-Push blob 'hi.txt' into an OCI layout folder 'layout-dir':
+Push blob 'hi.txt' into an OCI image layout folder 'layout-dir':
 
 ```bash
 oras blob push --oci-layout layout-dir hi.txt
@@ -65,15 +66,20 @@ oras blob push --oci-layout layout-dir hi.txt
 
 ```
       --ca-file string                             server certificate authority file for the remote registry
-  -d, --debug                                      debug mode
+      --cert-file string                           client certificate file for the remote registry
+  -d, --debug                                      output debug logs (implies --no-tty)
       --descriptor                                 output the descriptor
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for push
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
       --media-type string                          specify the returned media type in the descriptor if --descriptor is used (default "application/vnd.oci.image.layer.v1.tar")
+      --no-tty                                     [Preview] do not show progress output
       --oci-layout                                 set target as an OCI image layout
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --pretty                                     prettify JSON objects printed to stdout
       --registry-config path                       path of the authentication file for registry

--- a/versioned_docs/version-1.2/commands/oras_manifest_delete.mdx
+++ b/versioned_docs/version-1.2/commands/oras_manifest_delete.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras manifest delete
-sidebar_position: 90
+sidebar_position: 100
+warning: Do NOT modify this generated file
 ---
 
 # oras manifest delete
 
-Delete a manifest from remote registry.
+Delete a manifest from remote registry
 
 ```bash
 oras manifest delete [flags] <name>{:<tag>|@<digest>}
@@ -16,40 +17,46 @@ oras manifest delete [flags] <name>{:<tag>|@<digest>}
 Delete a manifest tagged with 'v1' from repository 'localhost:5000/hello':
 
 ```bash
-  oras manifest delete localhost:5000/hello:v1
+oras manifest delete localhost:5000/hello:v1
 ```
 
 Delete a manifest without prompting confirmation:
 
 ```bash
-  oras manifest delete --force localhost:5000/hello:v1
+oras manifest delete --force localhost:5000/hello:v1
 ```
 
 Delete a manifest and print its descriptor:
 
 ```bash
-  oras manifest delete --descriptor localhost:5000/hello:v1
+oras manifest delete --descriptor localhost:5000/hello:v1
 ```
 
 Delete a manifest by digest 'sha256:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9' from repository 'localhost:5000/hello':
 
 ```bash
-  oras manifest delete localhost:5000/hello@sha:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
+oras manifest delete localhost:5000/hello@sha:99e4703fbf30916f549cd6bfa9cdbab614b5392fbe64fdee971359a77073cdf9
 ```
 
 ## Options
 
 ```
       --ca-file string                             server certificate authority file for the remote registry
-  -d, --debug                                      debug mode
+      --cert-file string                           client certificate file for the remote registry
+  -d, --debug                                      output debug logs (implies --no-tty)
       --descriptor                                 output the descriptor
-      --distribution-spec string                   [Preview] set OCI distribution spec version and API option for target. options: v1.1-referrers-api, v1.1-referrers-tag
+      --distribution-spec string                   [Preview] set OCI distribution spec version and API option for target. Options: v1.1-referrers-tag, v1.1-referrers-api
   -f, --force                                      ignore nonexistent references, never prompt
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for delete
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
+      --no-tty                                     [Preview] do not show progress output
+      --oci-layout                                 set target as an OCI image layout
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --pretty                                     prettify JSON objects printed to stdout
       --registry-config path                       path of the authentication file for registry

--- a/versioned_docs/version-1.2/commands/oras_manifest_fetch-config.mdx
+++ b/versioned_docs/version-1.2/commands/oras_manifest_fetch-config.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras manifest fetch-config
-sidebar_position: 100
+sidebar_position: 120
+warning: Do NOT modify this generated file
 ---
 
 # oras manifest fetch-config
 
-Fetch the config of a manifest from a remote registry.
+Fetch the config of a manifest from a registry or an OCI image layout
 
 ```bash
 oras manifest fetch-config [flags] <name>{:<tag>|@<digest>}
@@ -49,21 +50,24 @@ Fetch and print the prettified descriptor of the config:
 oras manifest fetch-config --descriptor --pretty localhost:5000/hello:v1
 ```
 
-
 ## Options
 
 ```
       --ca-file string                              server certificate authority file for the remote registry
-  -d, --debug                                       debug mode
+      --cert-file string                            client certificate file for the remote registry
+  -d, --debug                                       output debug logs (implies --no-tty)
       --descriptor                                  output the descriptor
   -H, --header stringArray                          add custom headers to requests
-  -h, --help                                        help for fetch
+  -h, --help                                        help for fetch-config
+      --identity-token string                       registry identity token
+      --identity-token-stdin                        read identity token from stdin
       --insecure                                    allow connections to SSL registry without certs
-      --media-type strings                          accepted media types
+      --key-file string                             client private key file for the remote registry
+      --no-tty                                      [Preview] do not show progress output
       --oci-layout                                  set target as an OCI image layout
-  -o, --output path                                 file path to write the fetched manifest to, use - for stdout
+  -o, --output path                                 file path to write the fetched config to, use - for stdout
   -p, --password string                             registry password or identity token
-      --password-stdin                              read password or identity token from stdin
+      --password-stdin                              read password from stdin
       --plain-http                                  allow insecure connections to registry without SSL check
       --platform os[/arch][/variant][:os_version]   request platform in the form of os[/arch][/variant][:os_version]
       --pretty                                      prettify JSON objects printed to stdout

--- a/versioned_docs/version-1.2/commands/oras_manifest_fetch.mdx
+++ b/versioned_docs/version-1.2/commands/oras_manifest_fetch.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras manifest fetch
 sidebar_position: 110
+warning: Do NOT modify this generated file
 ---
 
 # oras manifest fetch
 
-Fetch manifest of the target artifact.
+Fetch manifest of the target artifact
 
 ```bash
 oras manifest fetch [flags] <name>{:<tag>|@<digest>}
@@ -43,7 +44,7 @@ Fetch manifest from a registry with prettified json result:
 oras manifest fetch --pretty localhost:5000/hello:v1
 ```
 
-Fetch raw manifest from an OCI layout folder 'layout-dir':
+Fetch raw manifest from an OCI image layout folder 'layout-dir':
 
 ```bash
 oras manifest fetch --oci-layout layout-dir:v1
@@ -59,20 +60,30 @@ oras manifest fetch --oci-layout layout.tar:v1
 
 ```
       --ca-file string                              server certificate authority file for the remote registry
-  -d, --debug                                       debug mode
+      --cert-file string                            client certificate file for the remote registry
+  -d, --debug                                       output debug logs (implies --no-tty)
       --descriptor                                  output the descriptor
+      --format string                               [Experimental] Format output using a custom template:
+                                                    'json':         Print in prettified JSON format
+                                                    'go-template':  Print using the given Go template
+  -H, --header stringArray                          add custom headers to requests
   -h, --help                                        help for fetch
+      --identity-token string                       registry identity token
+      --identity-token-stdin                        read identity token from stdin
       --insecure                                    allow connections to SSL registry without certs
+      --key-file string                             client private key file for the remote registry
       --media-type strings                          accepted media types
-      --oci-layout                                  set target as an OCI image layout.
+      --no-tty                                      [Preview] do not show progress output
+      --oci-layout                                  set target as an OCI image layout
   -o, --output path                                 file path to write the fetched manifest to, use - for stdout
   -p, --password string                             registry password or identity token
-      --password-stdin                              read password or identity token from stdin
+      --password-stdin                              read password from stdin
       --plain-http                                  allow insecure connections to registry without SSL check
       --platform os[/arch][/variant][:os_version]   request platform in the form of os[/arch][/variant][:os_version]
       --pretty                                      prettify JSON objects printed to stdout
-      --registry-config path                        path of the authentication file
-      --resolve host:port:address                   customized DNS formatted in host:port:address
+      --registry-config path                        path of the authentication file for registry
+      --resolve host:port:address[:address_port]    customized DNS for registry, formatted in host:port:address[:address_port]
+      --template string                             [Experimental] Template string used to format output
   -u, --username string                             registry username
   -v, --verbose                                     verbose output
 ```

--- a/versioned_docs/version-1.2/commands/oras_manifest_push.mdx
+++ b/versioned_docs/version-1.2/commands/oras_manifest_push.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras manifest push
-sidebar_position: 120
+sidebar_position: 130
+warning: Do NOT modify this generated file
 ---
 
 # oras manifest push
 
-Push a manifest to remote registry.
+Push a manifest to a registry or an OCI image layout
 
 ```bash
 oras manifest push [flags] <name>[:<tag>[,<tag>][...]|@<digest>] <file>
@@ -62,7 +63,7 @@ Push a manifest to repository 'localhost:5000/hello' and tag with 'tag1', 'tag2'
 oras manifest push --concurrency 6 localhost:5000/hello:tag1,tag2,tag3 manifest.json
 ```
 
-Push a manifest to an OCI layout folder 'layout-dir' and tag with 'v1':
+Push a manifest to an OCI image layout folder 'layout-dir' and tag with 'v1':
 
 ```bash
 oras manifest push --oci-layout layout-dir:v1 manifest.json
@@ -72,17 +73,22 @@ oras manifest push --oci-layout layout-dir:v1 manifest.json
 
 ```
       --ca-file string                             server certificate authority file for the remote registry
+      --cert-file string                           client certificate file for the remote registry
       --concurrency int                            concurrency level (default 5)
-  -d, --debug                                      debug mode
+  -d, --debug                                      output debug logs (implies --no-tty)
       --descriptor                                 output the descriptor
-      --distribution-spec string                   [Preview] set OCI distribution spec version and API option for target. options: v1.1-referrers-api, v1.1-referrers-tag
+      --distribution-spec string                   [Preview] set OCI distribution spec version and API option for target. Options: v1.1-referrers-tag, v1.1-referrers-api
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for push
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
       --media-type string                          media type of manifest
+      --no-tty                                     [Preview] do not show progress output
       --oci-layout                                 set target as an OCI image layout
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --pretty                                     prettify JSON objects printed to stdout
       --registry-config path                       path of the authentication file for registry

--- a/versioned_docs/version-1.2/commands/oras_repo_ls.mdx
+++ b/versioned_docs/version-1.2/commands/oras_repo_ls.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras repo ls
-sidebar_position: 150
+sidebar_position: 160
+warning: Do NOT modify this generated file
 ---
 
 # oras repo ls
 
-List the repositories under the registry.
+List the repositories under the registry
 
 ```bash
 oras repo ls [flags] <registry>
@@ -13,19 +14,19 @@ oras repo ls [flags] <registry>
 
 ## Examples
 
-Example - List the repositories under the registry:
+List the repositories under the registry:
 
 ```bash
 oras repo ls localhost:5000
 ```
 
-Example - List the repositories under a namespace in the registry:
+List the repositories under a namespace in the registry:
 
 ```bash
 oras repo ls localhost:5000/example-namespace
 ```
 
-Example - List the repositories under the registry that include values lexically after last:
+List the repositories under the registry that include values lexically after last:
 
 ```bash
 oras repo ls --last "last_repo" localhost:5000
@@ -33,15 +34,20 @@ oras repo ls --last "last_repo" localhost:5000
 
 ## Options
 
-```bash
+```
       --ca-file string                             server certificate authority file for the remote registry
-  -d, --debug                                      debug mode
+      --cert-file string                           client certificate file for the remote registry
+  -d, --debug                                      output debug logs (implies --no-tty)
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for ls
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
       --last last                                  start after the repository specified by last
+      --no-tty                                     [Preview] do not show progress output
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --registry-config path                       path of the authentication file for registry
       --resolve host:port:address[:address_port]   customized DNS for registry, formatted in host:port:address[:address_port]

--- a/versioned_docs/version-1.2/commands/oras_repo_tags.mdx
+++ b/versioned_docs/version-1.2/commands/oras_repo_tags.mdx
@@ -1,11 +1,12 @@
 ---
 title: oras repo tags
-sidebar_position: 160
+sidebar_position: 170
+warning: Do NOT modify this generated file
 ---
 
 # oras repo tags
 
-Show tags of the target repository.
+Show tags of the target repository
 
 ```bash
 oras repo tags [flags] <name>
@@ -31,7 +32,7 @@ Show tags of the target repository that include values lexically after last:
 oras repo tags --last "last_tag" localhost:5000/hello
 ```
 
-Show tags of the target OCI layout folder 'layout-dir':
+Show tags of the target OCI image layout folder 'layout-dir':
 
 ```bash
 oras repo tags --oci-layout layout-dir
@@ -43,13 +44,13 @@ Show tags of the target OCI layout archive 'layout.tar':
 oras repo tags --oci-layout layout.tar
 ```
 
-Show tags associated with a particular tagged resource:
+[Experimental] Show tags associated with a particular tagged resource:
 
 ```bash
 oras repo tags localhost:5000/hello:latest
 ```
 
-Show tags associated with a digest:
+[Experimental] Show tags associated with a digest:
 
 ```bash
 oras repo tags localhost:5000/hello@sha256:c551125a624189cece9135981621f3f3144564ddabe14b523507bf74c2281d9b
@@ -59,15 +60,20 @@ oras repo tags localhost:5000/hello@sha256:c551125a624189cece9135981621f3f314456
 
 ```
       --ca-file string                             server certificate authority file for the remote registry
-  -d, --debug                                      debug mode
+      --cert-file string                           client certificate file for the remote registry
+  -d, --debug                                      output debug logs (implies --no-tty)
       --exclude-digest-tags                        [Preview] exclude all digest-like tags such as 'sha256-aaaa...'
   -H, --header stringArray                         add custom headers to requests
   -h, --help                                       help for tags
+      --identity-token string                      registry identity token
+      --identity-token-stdin                       read identity token from stdin
       --insecure                                   allow connections to SSL registry without certs
+      --key-file string                            client private key file for the remote registry
       --last last                                  start after the tag specified by last
+      --no-tty                                     [Preview] do not show progress output
       --oci-layout                                 set target as an OCI image layout
   -p, --password string                            registry password or identity token
-      --password-stdin                             read password or identity token from stdin
+      --password-stdin                             read password from stdin
       --plain-http                                 allow insecure connections to registry without SSL check
       --registry-config path                       path of the authentication file for registry
       --resolve host:port:address[:address_port]   customized DNS for registry, formatted in host:port:address[:address_port]


### PR DESCRIPTION
There were several simultaneous PRs and it made it difficult to detect these errors in subcommand generation.

* The list command for subcommands needed an argument
* The directory was wrong for subcommands
* Logic was backwards on detecting subcommands
* Was not actually updating the subcommands in versioned_docs