### PR TITLE
chore: Update go script for data capture

### DIFF
--- a/versioned_docs/version-1.2/how_to_guides/go_script.mdx
+++ b/versioned_docs/version-1.2/how_to_guides/go_script.mdx
@@ -28,12 +28,11 @@ func main() {
 	cmd.SetOut(builder)
 	fmt.Printf("Executing 'oras %s':", strings.Join(args, " "))
 	err := cmd.Execute()
+	fmt.Println(builder.String())
 	if err != nil {
-		fmt.Println(builder.String())
 		fmt.Errorf("Failed to execute : %w", err)
 		os.Exit(-1)
 	}
-	fmt.Println(builder.String())
 	os.Exit(0)
 }
 ```

--- a/versioned_docs/version-1.2/how_to_guides/go_script.mdx
+++ b/versioned_docs/version-1.2/how_to_guides/go_script.mdx
@@ -24,12 +24,16 @@ func main() {
 	args := []string{"repo", "ls", "mcr.microsoft.com"}
 	cmd := root.New()
 	cmd.SetArgs(args)
+	builder := &strings.Builder{}
+	cmd.SetOut(builder)
 	fmt.Printf("Executing 'oras %s':", strings.Join(args, " "))
 	err := cmd.Execute()
 	if err != nil {
+		fmt.Println(builder.String())
 		fmt.Errorf("Failed to execute : %w", err)
 		os.Exit(-1)
 	}
+	fmt.Println(builder.String())
 	os.Exit(0)
 }
 ```


### PR DESCRIPTION
Update the go script documentation for stdout capture. This works for 1.2, but stderr capture is not part of 1.2.