### PR TITLE
fix: redirect for community page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,8 @@
     paths = [
       "node_modules/.cache",
     ]
+
+[[redirects]]
+  from = "/docs/community/*"
+  to = "/community/:splat"
+  status = 301


### PR DESCRIPTION
Redirects from old /docs/community to new /community

Closes: https://github.com/oras-project/oras-www/issues/348

https://deploy-preview-388--oras-project.netlify.app/docs/community/community_resources

redirects to 

https://deploy-preview-388--oras-project.netlify.app/community/community_resources