### PR TITLE
chore: add github action for vale

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -1,0 +1,17 @@
+name: vale
+on: [pull_request]
+
+jobs:
+  vale:
+    name: runner / vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: errata-ai/vale-action@v2
+        with:
+          files: '["community", "versioned_docs"]'
+          debug: true
+          fail_on_error: true
+          reporter: github-pr-check
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Add vale github action

Does not block PRs now https://github.com/oras-project/oras-www/actions/runs/10852551086/job/30118842300?pr=392 but reports errors.

Closes: https://github.com/oras-project/oras-www/issues/113