### PR TITLE
Rust: update rust OCI client crate name

### DIFF
--- a/versioned_docs/version-1.2/client_libraries/rust.mdx
+++ b/versioned_docs/version-1.2/client_libraries/rust.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 ### Crate 
 
-- [crates.io/crates/oci-distribution](https://crates.io/crates/oci-distribution)
+- [crates.io/crates/oci-client](https://crates.io/crates/oci-client)
 
 ### Repository
 


### PR DESCRIPTION
Rust OCI client has been [renamed](https://github.com/oras-project/rust-oci-client/commit/5c2e9231eb979215d121c0abdfd0e4690144f492) from [oci-distribution](https://crates.io/crates/oci-distribution) to [oci-client](https://crates.io/crates/oci-client).