### PR TITLE
fix: resolves make truncate warning

### DIFF
--- a/blog/2024-05-29-oras-1.2.0-and-oras-go-2.5.0/index.mdx
+++ b/blog/2024-05-29-oras-1.2.0-and-oras-go-2.5.0/index.mdx
@@ -9,6 +9,8 @@ tags: [oras, artifact]
 The [ORAS](https://oras.land/) project maintainers are proud to announce ORAS CLI v1.2.0 and ORAS-go v2.5.0. These two releases are ready for production use. ORAS CLI v1.2.0 introduces OCI Spec v1.1.0 support, formatted output, brand-new terminal experience with progress bar, and more! 
 This article walks you through the notable features and how these enhancements benefit ORAS users as well as the cloud-native ecosystem.
 
+<!--truncate-->
+
 ## What's new in ORAS v1.2.0
 
 ### OCI Spec v1.1.0 support


### PR DESCRIPTION
Gets rid of this warning:
```
[WARNING] Docusaurus found blog posts without truncation markers:
- "blog/2024-05-29-oras-1.2.0-and-oras-go-2.5.0/index.mdx"

We recommend using truncation markers (`<!-- truncate -->` or `{/* truncate */}`) in blog posts to create shorter previews on blog paginated lists.
Tip: turn this security off with the `onUntruncatedBlogPosts: 'ignore'` blog plugin option.
```