### PR TITLE
fix: vale working on ubuntu-latest

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -7,6 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # create venv workaround for https://github.com/errata-ai/vale-action/issues/128
+      - run: |
+          venv="$HOME/.local/share/venv"
+          python3 -m venv "$venv"
+          echo "$venv/bin" >> $GITHUB_PATH
       - uses: errata-ai/vale-action@v2
         with:
           files: '["community", "versioned_docs"]'


### PR DESCRIPTION
Related: https://github.com/errata-ai/vale-action/issues/128

```
Ensuring core python and ruby dependencies are present
/usr/bin/pip install docutils
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
Error: Error: The process '/usr/bin/pip' failed with exit code 1
```