### PR TITLE
chore: avoid dependabot conflict with docusaurus core package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
             "version": "0.0.0",
             "dependencies": {
                 "@docusaurus/core": "^3.6.0",
-                "@docusaurus/preset-classic": "^3.6.0",
+                "@docusaurus/preset-classic": "",
                 "@docusaurus/theme-common": "^3.6.0",
-                "@docusaurus/theme-mermaid": "^3.6.0",
+                "@docusaurus/theme-mermaid": "",
                 "@docusaurus/types": "^3.6.1",
                 "@fortawesome/fontawesome-free": "^6.6.0",
                 "@mdx-js/react": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
         "refresh-commands": "./tools/refresh-commands.sh",
         "check-links": "remark --frail --use remark-validate-links \"docs/**/*.{md,mdx}\" \"blog/**/*.{md,mdx}\" \"community/**/*.{md,mdx}\" ."
     },
+    "//": "preset-classic and theme-mermaid require exact core version match",
     "dependencies": {
         "@docusaurus/core": "^3.6.0",
-        "@docusaurus/preset-classic": "^3.6.0",
+        "@docusaurus/preset-classic": "",
         "@docusaurus/theme-common": "^3.6.0",
-        "@docusaurus/theme-mermaid": "^3.6.0",
+        "@docusaurus/theme-mermaid": "",
         "@docusaurus/types": "^3.6.1",
         "@fortawesome/fontawesome-free": "^6.6.0",
         "@mdx-js/react": "^3.1.0",


### PR DESCRIPTION
The packages preset-classic and theme-mermaid require exact docusaurus/core version match.

This PR will make PRs like https://github.com/oras-project/oras-www/pull/422 unnecessary.