### PR TITLE
fix: allow lower level subcommands

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -7,9 +7,7 @@ OS="$(uname -s | tr A-Z a-z)"
 ARCH=$(test "$(uname -m)" = 'x86_64' && echo 'amd64' || echo 'arm64')
 
 cd ${TEMPDIR}
-ORAS_COMMAND="${TEMPDIR}/oras"
 OUTPUT_FILE="${TEMPDIR}/oras.tgz"
 curl -s -o ${OUTPUT_FILE} -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_${OS}_${ARCH}.tar.gz" >&2
 tar -zxf ${OUTPUT_FILE} oras >&2
 rm -f ${OUTPUT_FILE}
-echo "${ORAS_COMMAND}"

--- a/tools/list_commands.sh
+++ b/tools/list_commands.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+COMMAND="${1?First argument is command}"
+
+STATE='Usage'
+oras help ${COMMAND} | grep -v '^  completion'| while read LINE
+do
+    [[ "${LINE}" == "" ]] && continue
+
+    case "${STATE}" in
+    Usage)
+        if [[ "${LINE}" == Available* ]]
+        then
+            STATE='Commands'
+            continue
+        fi
+        ;;
+    Commands)
+        if [[ "${LINE}" == Flags* ]]
+        then
+            STATE='Flags'
+            continue
+        fi
+        COMMAND=$(echo "${LINE}" | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]].*//')
+        echo ${COMMAND}
+        ;;
+    Flags)
+        ;;
+    esac
+done

--- a/tools/parse.sh
+++ b/tools/parse.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-TEMPDIR="${1?First argument is temporary directory}"
-COMMAND="${2?Second argument is command to run}"
-WEIGHT="${3?Third argument is weight}"
-ORAS="${TEMPDIR}/oras"
+COMMAND="${1?First argument is command to run}"
+WEIGHT="${2?Second argument is weight}"
+
+TEMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEMPDIR"' EXIT
 
 echo '---'
 echo "title: oras ${COMMAND}"
@@ -20,7 +21,7 @@ echo
 TEMPFILE="${TEMPDIR}/help"
 EXAMPLES_FILE="${TEMPDIR}/examples"
 trap 'rm -f "$TEMPFILE" "$EXAMPLES_FILE"' EXIT
-${ORAS} help ${COMMAND} >${TEMPFILE}
+oras help ${COMMAND} >${TEMPFILE}
 
 IFS=''
 STATE=Introduction

--- a/tools/refresh-commands.sh
+++ b/tools/refresh-commands.sh
@@ -29,7 +29,6 @@ do
     ./tools/install.sh ${LATEST_VERSION} ${TEMPDIR}
     export PATH=${TEMPDIR}:${PATH}
     VERSIONED_DOCS=versioned_docs/version-${VERSION}/commands
-    which oras
     oras help | ./tools/parse_main.sh >"${VERSIONED_DOCS}/use_oras_cli.mdx"
     ./tools/subcommands.sh "" "${VERSIONED_DOCS}"
 done

--- a/tools/refresh-commands.sh
+++ b/tools/refresh-commands.sh
@@ -21,76 +21,15 @@ map_version() {
     grep "^$1" versions-latest || echo "$1.0"
 }
 
-list_commands() {
-    STATE='Usage'
-    IFS=''
-    ${ORAS_COMMAND} help ${1} | grep -v '^  completion'| while read LINE
-    do
-        [[ "${LINE}" == "" ]] && continue
-
-        case "${STATE}" in
-        Usage)
-            if [[ "${LINE}" == Available* ]]
-            then
-                STATE='Commands'
-                continue
-            fi
-            ;;
-        Commands)
-            if [[ "${LINE}" == Flags* ]]
-            then
-                STATE='Flags'
-                continue
-            fi
-            COMMAND=$(echo "${LINE}" | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]].*//')
-            echo ${COMMAND}
-            ;;
-        Flags)
-            ;;
-        esac
-    done
-}
-
-DIFFS=false
 VERSIONS=$(tr '[]",' ' ' <versions.json)
 for VERSION
 in ${VERSIONS}
 do
     LATEST_VERSION=$(map_version $VERSION)
-    ORAS_COMMAND=$(./tools/install.sh ${LATEST_VERSION} ${TEMPDIR})
-    WEIGHT=10
+    ./tools/install.sh ${LATEST_VERSION} ${TEMPDIR}
+    export PATH=${TEMPDIR}:${PATH}
     VERSIONED_DOCS=versioned_docs/version-${VERSION}/commands
-    ${ORAS_COMMAND} help | ./tools/parse_main.sh >"${VERSIONED_DOCS}/use_oras_cli.mdx"
-    list_commands >"${TEMPDIR}/commands"
-    while read COMMAND
-    do
-        list_commands "${COMMAND}" >"${TEMPDIR}/subcommands"
-        if [ ! -s "${TEMPDIR}/subcommands" ]
-        then
-            FILE="${VERSIONED_DOCS}/oras_${COMMAND}.mdx"
-            ./tools/parse.sh ${TEMPDIR} "${COMMAND}" $WEIGHT >"${FILE}"
-            if git diff "${FILE}" >/dev/null
-            then
-                DIFFS=true
-            fi
-            WEIGHT=$(expr $WEIGHT + 10)
-        else
-            while read SUBCOMMAND
-            do
-                FILE="${VERSIONED_DOCS}/oras_${COMMAND}_${SUBCOMMAND}.mdx"
-                ./tools/parse.sh ${TEMPDIR} "${COMMAND} ${SUBCOMMAND}" $WEIGHT >"${FILE}"
-                if git diff "${FILE}" >/dev/null
-                then
-                    DIFFS=true
-                fi
-                WEIGHT=$(expr $WEIGHT + 10)
-            done <"${TEMPDIR}/subcommands"
-        fi
-    done <"${TEMPDIR}/commands"
+    which oras
+    oras help | ./tools/parse_main.sh >"${VERSIONED_DOCS}/use_oras_cli.mdx"
+    ./tools/subcommands.sh "" "${VERSIONED_DOCS}"
 done
-if $DIFFS
-then
-    echo
-    echo '** Command generator made updates **'
-    echo
-fi

--- a/tools/subcommands.sh
+++ b/tools/subcommands.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+COMMAND="${1?First argument is command}"
+DESTINATION="${2?Second argument is destination directory}"
+
+TEMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEMPDIR"' EXIT
+WEIGHT_FILE="${3}"
+if [ "${WEIGHT_FILE}" == "" ]
+then
+    WEIGHT_FILE="${3:-${TEMPDIR}/weight}"
+    echo 10 >${WEIGHT_FILE}
+fi
+
+./tools/list_commands.sh  "${COMMAND}" "${DESTINATION}" >"${TEMPDIR}/subcommands"
+if [ ! -s "${TEMPDIR}/subcommands" ]
+then
+    WEIGHT=$(cat $WEIGHT_FILE)
+    FILE="${DESTINATION}/oras_$(echo ${COMMAND} | sed -e 's/ /_/g').mdx"
+    ./tools/parse.sh "${COMMAND}" "$WEIGHT" >"${FILE}"
+    if ! git diff --quiet "${FILE}"
+    then
+        echo "** Updated ${FILE} **"
+    fi
+    echo $(expr $WEIGHT + 10) >${WEIGHT_FILE}
+    exit 0
+fi
+while read SUBCOMMAND
+do
+    ./tools/subcommands.sh "$(echo ${COMMAND} ${SUBCOMMAND})" "${DESTINATION}" "${WEIGHT_FILE}"
+done <"${TEMPDIR}/subcommands"


### PR DESCRIPTION
The current command document generator only does two levels of commands. The introduction of `oras manifest index create` is three levels. While this PR is a bit tough to look at, the actual code is a lot easier to look at.

* Broke out `list_command.sh` into a shell script that can be run and tested by itself for example `./tools/list_command manifest index`
* Simplified the path to the current `oras` command so it doesn't need to be passed around
* Simplified temp file handling
* Created `subcommands.sh` that either prints the command or iterates through the subcommands which can be run for example `./tools/subcommands.sh manifest ./versioned_docs/version-1.3.0-beta.1/commands `