### PR TITLE
Allow two github spellings

### DIFF
--- a/vale/config/vocabularies/oras/accept.txt
+++ b/vale/config/vocabularies/oras/accept.txt
@@ -10,7 +10,8 @@ Dockerfile
 facto
 filetype
 gcloud
-[Gg]ithub
+github
+GitHub
 [Gg]olang
 (?i)http
 https


### PR DESCRIPTION
There were a bunch of warnings before, with this:
```
Run errata-ai/vale-action@v2
  with:
    files: ["community", "versioned_docs"]
    debug: true
    fail_on_error: true
    reporter: github-pr-check
    version: latest
    level: error
    filter_mode: added
    token: ***
  env:
    GITHUB_TOKEN: ***
Installing Vale version 'latest' ...
/usr/bin/tar xz --overwrite --warning=no-unknown-keyword --overwrite -C /home/runner -f /home/runner/work/_temp/74[2](https://github.com/oras-project/oras-www/actions/runs/12521551653/job/34928761208?pr=444#step:4:2)f37cc-54e7-4[3](https://github.com/oras-project/oras-www/actions/runs/12521551653/job/34928761208?pr=444#step:4:3)57-84ec-86e4523d93fb
Installed version '3.9.2' into '/home/runner/vale'.
Installing ReviewDog version '0.17.0' ...
/usr/bin/tar xz --overwrite --warning=no-unknown-keyword --overwrite -C /home/runner -f /home/runner/work/_temp/63d761d9-9f58-[4](https://github.com/oras-project/oras-www/actions/runs/12521551653/job/34928761208?pr=444#step:4:4)174-a930-5c10d1049ee9
Installed reviewdog from 'https://github.com/reviewdog/reviewdog/releases/download/v0.17.0/reviewdog_0.17.0_Linux_x86_64.tar.gz' into '/home/runner/reviewdog'.
Using Vale 3.9.2
/home/runner/vale sync
2[5](https://github.com/oras-project/oras-www/actions/runs/12521551653/job/34928761208?pr=444#step:4:5)l

                                                                                
 SUCCESS  Synced 0 package(s) to '/home/runner/work/oras-www/oras-www/vale'.
```