### PR TITLE
fix: Formatting Issue on doc

### DIFF
--- a/versioned_docs/version-1.2/compatible_oci_registries.mdx
+++ b/versioned_docs/version-1.2/compatible_oci_registries.mdx
@@ -86,10 +86,11 @@ To login to the registry without a certificate, a self-signed certificate, or an
 - Generate your self-signed certificates:
 
   ```
-  $ mkdir -p certs
-  $ openssl req \
-    -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key \
-    -x509 -days 365 -out certs/domain.crt
+  mkdir -p certs && \
+  openssl req \
+  -newkey rsa:4096 -nodes -sha256 \
+  -keyout certs/domain.key \
+  -x509 -days 365 -out certs/domain.crt
   ```
 
 - Start a registry using that file for auth and listen the `0.0.0.0` address:


### PR DESCRIPTION
### Fixes #446 
As  the documentation uses the `$` prefix in the command  here https://github.com/oras-project/oras-www/blob/4e73bda9c69b1a31c0ddd345f01b35c0249b763e/versioned_docs/version-1.2/compatible_oci_registries.mdx?plain=1#L89-L93

Which causes an error while using the terminal, After adding a separator it works fine...

### preview after fixing
<img width="826" alt="Screenshot 2024-12-31 at 1 53 52 AM" src="https://github.com/user-attachments/assets/2658116c-93a9-45c3-aaad-f771bf264140" />
