### PR TITLE
fix: Add PowerShell to acceptable spellings

### DIFF
--- a/vale/config/vocabularies/oras/accept.txt
+++ b/vale/config/vocabularies/oras/accept.txt
@@ -25,6 +25,7 @@ namespace
 Nixpkgs
 polytree
 powershell
+PowerShell
 pullable
 releaser
 repo


### PR DESCRIPTION
Lower case `powershell` is used by the completion command.