### PR TITLE
fix: update link for latest documentations

### DIFF
--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -12,7 +12,7 @@ export default function DocVersionBanner() {
       <div style={{ background: '#FFF4DB', padding: '10px', borderRadius: '5px' }}>
         <strong>This is documentation for OCI Registry As Storage <b>1.3.0-beta</b>, which is in a preview status.</strong>
         <br />
-        For a stable release documentation, see the <a href="/docs/latest">latest version (1.2)</a>.
+        For a stable release documentation, see the <a href="/docs">latest version (1.2)</a>.
       </div>
     );
   }


### PR DESCRIPTION
This pull request includes a minor update to the `DocVersionBanner` component. The change updates the link for the stable release documentation to point to the `/docs` endpoint instead of `/docs/latest`.

Fixes #471 