### PR TITLE
fix: add truncate for page preview

### DIFF
--- a/blog/2025-04-28-oras-1.3.0-beta.3/index.mdx
+++ b/blog/2025-04-28-oras-1.3.0-beta.3/index.mdx
@@ -7,6 +7,8 @@ tags: [oras, artifact]
 
 The ORAS Community is thrilled to announce the release of `ORAS v1.3.0-beta.3`! This milestone continues our vision to make managing OCI artifacts easier, faster, and more intuitive for users and developers.
 
+<!--truncate-->
+
 This release includes new features, critical improvements, and bug fixes as we fine-tune ORAS for the upcoming stable release. Let’s dive into what’s new!
 
 ## ✨ What's New?


### PR DESCRIPTION
The 1.3.0-beta.3 page should have truncate for preview