### PR TITLE
docs: improve release process

### DIFF
--- a/community/release-process.mdx
+++ b/community/release-process.mdx
@@ -55,6 +55,11 @@ This section needs a lot of love and automation 🙂
     ./oras-bin/oras version
     ```
 
+1. After validation, remove the temporary oras-bin directory:
+    ```sh
+    rm -rf oras-bin/
+    ```
+
 1. Create armored GPG signatures(`.asc`) using the key in the `KEYS` file.
     ```sh
     for file in `ls`; do
@@ -64,7 +69,13 @@ This section needs a lot of love and automation 🙂
 1. Validate the signatures. Note that the `KEYS` file should be imported with `gpg --import KEYS`. Run some form of the following (adapted from Linux project):
     ```sh
     for file in `ls *.asc`; do
-        gpg --verify $file
+        echo "Verifying: $file"
+        if gpg --verify "$file"; then
+            echo "✅ Good signature for $file"
+        else
+            echo "❌ BAD signature for $file"
+        fi
+        echo "----------------------------------------"
     done
     ```
 1. Click the "Edit release" button on the release, and add the `.asc` files created in the previous step. Edit the release description to include change logs and a note indicating the releaser's GPG key used to sign the artifacts. See an example:


### PR DESCRIPTION
1. Add a step to remove the temporary oras-bin director
2. Refine the script for signature validation to make the output more readable

Example output:
<img width="1268" height="1175" alt="image" src="https://github.com/user-attachments/assets/0b98d74a-fde6-4aa2-b271-1c7640a3c35a" />


Page preview: https://deploy-preview-490--oras-project.netlify.app/community/release-process