### PR TITLE
docs: replace Gitpod with generic IDE/CDE reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,15 @@ Source for ORAS website and documentation
 
 # Development
 
-## Online one-click setup
+## Development Setup
 
-You can use Gitpod (a free, online, VS Code-like IDE) for contributing. With a single click, it will launch a workspace (for Docusaurus 2) automatically:
+You can use your favorite IDE or cloud development environment (CDE) for contributing. Simply:
 
--   clone the docusaurus repo.
--   install the dependencies.
+-   clone the repository
+-   install the dependencies
 -   run `npm start`
 
-So that you can start contributing straight away.
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/oras-project/oras-www)
+Then you can start contributing straight away.
 
 ## System Requirements
 


### PR DESCRIPTION
gitpod no longer exists in this form

Closes: https://github.com/oras-project/oras-www/issues/508