### PR TITLE
chore: move Steve Lasker to emeritus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @asmitbm @FeynmanZhou @sajayantony @shizhMSFT @stevelasker @vsoch @TerryHowe
+* @asmitbm @FeynmanZhou @sajayantony @shizhMSFT @vsoch @TerryHowe

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -5,10 +5,10 @@ Owners:
   - Feynman Zhou (@FeynmanZhou)
   - Sajay Antony (@sajayantony)
   - Shiwei Zhang (@shizhMSFT)
-  - Steve Lasker (@stevelasker)
   - Vanessasaurus (@vsoch)
   - Terry Howe (@TerryHowe)
 
 Emeritus:
   - Avi Deitcher (@deitch)
   - Josh Dolitsky (@jdolitsky)
+  - Steve Lasker (@stevelasker)


### PR DESCRIPTION
Steve Lasker has not been active for over six months. While Steve's contributions are greatly appreciated, priorities change.