### PR TITLE
build: upgrade Node.js requirement to v24 (Active LTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ Source for ORAS website and documentation
 
 You can use your favorite IDE or cloud development environment (CDE) for contributing. Simply:
 
--   clone the repository
--   install the dependencies
--   run `npm start`
+- clone the repository
+- install the dependencies
+- run `npm start`
 
 Then you can start contributing straight away.
 
 ## System Requirements
 
--   [Node.js v18.x](https://nodejs.org/en/download/) and above
+- [Node.js v24.x](https://nodejs.org/en/download/) and above
 
 ## Installation
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   publish = "build"
 
 [build.environment]
-  NODE_VERSION = "21"
+  NODE_VERSION = "24"
 
 [[plugins]]
   package = "netlify-plugin-cache"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "remark-validate-links": "^13.1.0"
             },
             "engines": {
-                "node": ">=18.0"
+                "node": ">=24.0"
             }
         },
         "node_modules/@ai-sdk/gateway": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "docusaurus": "docusaurus",
         "start": "npm run refresh-commands && npm run check-links && docusaurus start",
-        "build": "npm run refresh-commands && npm run check-links && docusaurus build",
+        "build": "npm run refresh-commands && npm run check-links && NODE_OPTIONS='--localstorage-file=/tmp/docusaurus-localstorage' docusaurus build",
         "swizzle": "docusaurus swizzle",
         "deploy": "docusaurus deploy",
         "clear": "docusaurus clear",
@@ -50,6 +50,6 @@
         ]
     },
     "engines": {
-        "node": ">=18.0"
+        "node": ">=24.0"
     }
 }


### PR DESCRIPTION
Bumping up nodejs version to active LTS -  https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch
> 18 was last updated - Mar 27, 2025 - 

<img width="763" height="346" alt="image" src="https://github.com/user-attachments/assets/ffeab0c4-c5b8-4a8f-99aa-51f93380f3e3" />


- Update package.json engines field to require Node.js >=24.0
- Update README.md to reference Node.js v24.x
- Update Netlify configuration to use Node.js 24
- Add NODE_OPTIONS flag to build script for localStorage compatibility
- GitHub Actions workflows automatically use Node.js 24 via package.j