### PR TITLE
docs: simplify release tagging instructions

### DIFF
--- a/community/release-process.mdx
+++ b/community/release-process.mdx
@@ -21,9 +21,7 @@ This section is a work in progress and needs automation 🙂
         - `main` if releasing a new version.
         - `release-<major>.<minor>` if releasing a patch.
     - The title should be `bump: tag and release ORAS CLI v<major>.<minor>.<patch>[-<pre-release>]`.
-    - The description must reference the digest of version bump up commit for voting.
 1. Send a message to the ORAS slack channel to call for a vote on the release PR.
-    - The target commit should be the SHA digest of the last commit in the release PR
 1. If the vote PR has a super-majority of approval from ORAS maintainers, then the PR could be merged into the target branch.
     - Make sure that
         - the PR is merged with `Create a merge commit` option.
@@ -32,14 +30,11 @@ This section is a work in progress and needs automation 🙂
 1. (optional) Cut off a release branch named `release-<major>.<minor>` on the tagged commit **ONLY** when releasing a new minor version.
 
 ### Release
-1. Make a fresh clone of the [repository](https://github.com/oras-project/oras) after all above steps are completed. Create a new tag for the version prefixed with "v" and push the tag directly to the repository. The tag should be created on the voted commit, **NOT** the merge commit.
+1. Make a fresh clone of the [repository](https://github.com/oras-project/oras) after all above steps are completed. Create a new tag for the version prefixed with "v" and push the tag directly to the repository.
     ```sh
     version=1.0.0
-    digest=b58e7b910ca556973d111e9bd734a71baef03db2 # replace with the digest of the voted commit
-    git tag v${version} $digest
-    ```
-    After validating the tag is created on the voted commit, push the created tag:
-    ```sh
+    sha=b58e7b910ca556973d111e9bd734a71baef03db2 # replace with the SHA of the commit to tag
+    git tag v${version} $sha
     git push origin v${version}
     ```
 1. Wait for GitHub Actions to complete successfully for both the `release-ghcr` and `release-github` pipelines.


### PR DESCRIPTION
Remove the over-emphasis on voted commit vs merge commit distinction. The git and merge history already makes this clear to anyone who needs to know.