### PR TITLE
docs: restore snap installation instructions for v1.3

### DIFF
--- a/versioned_docs/version-1.3/installation.mdx
+++ b/versioned_docs/version-1.3/installation.mdx
@@ -7,6 +7,20 @@ sidebar_position: 15
 
 This guide demonstrates the installation steps of ORAS CLI on different platforms.
 
+## Snap
+
+Install `oras` using [Snap](https://snapcraft.io/oras) on Linux:
+
+```bash
+snap install oras --classic
+```
+
+:::note
+
+The `--classic` flag is required because ORAS uses classic confinement to access files outside the snap sandbox.
+
+:::
+
 ## Release artifacts
 
 Install ORAS from the latest [release artifacts](https://github.com/oras-project/oras/releases):
@@ -116,7 +130,7 @@ Git tree state: clean
 
 :::note
 
-ORAS on other package managers such as Homebrew, WinGet, Nix will be updated after the stable release.
+ORAS on other package managers such as Snap, Homebrew, WinGet, Nix will be updated after the stable release.
 
 :::
 


### PR DESCRIPTION
## Summary

The snap installation section was removed from the v1.3 docs, which prompted issue oras-project/oras#1965. Now that the snap release workflow is active and publishing to the Snap Store (as of oras-project/oras#2011), restore the installation instructions.

## Changes

- Adds a **Snap** section to `versioned_docs/version-1.3/installation.mdx` with `snap install oras --classic`
- Includes a note explaining that `--classic` is required because ORAS uses classic confinement to access files outside the snap sandbox
- Adds Snap to the list of package managers mentioned in the verification note

## Why `--classic` is required

ORAS is a CLI tool that reads and writes files at arbitrary paths provided by the user. Strict snap confinement would prevent this, so classic confinement is intentional and the `--classic` flag is unavoidable.

Fixes oras-project/oras#1965