### PR TITLE
docs: update oras discover JSON output format for v1.3.0

### DIFF
--- a/versioned_docs/version-1.3/how_to_guides/format_output.mdx
+++ b/versioned_docs/version-1.3/how_to_guides/format_output.mdx
@@ -269,17 +269,24 @@ $REGISTRY/$REPO@sha256:a3785f78ab8547ae2710c89e627783cfa7ee7824d3468cae6835c9f4e
 │   └── sha256:8dee8cb9a1334595545e3baf15c3eeed13c4b35ae08e3ab32e1df31fb152dc1d
 └── sbom/example
     └── sha256:50fd0dc107d84b5e7b402688000a7ed3aaf8a2692d5cb74da5277fa3c4cecf15
+        └── [annotations]
+            └── org.opencontainers.image.created: "2024-01-01T07:57:10Z"
 ```
 
 View an artifact's referrers manifest in pretty JSON output. The following fields should be outputted:
 
-- `manifests`: the list of referrers
+- `reference`: full reference by digest of the subject manifest
+- `mediaType`: media type of the subject manifest
+- `digest`: digest of the subject manifest
+- `size`: subject manifest file size in bytes
+- `referrers`: the list of artifacts that reference the subject
   - `reference`: full reference by digest of the referrer
   - `mediaType`: media type of the referrer
-  - `size`: referrer file size in bytes
   - `digest`: digest of the referrer
-  - `artifactType`: artifact type of a referrer
-  - `annotations`: contains arbitrary metadata in a referrer
+  - `size`: referrer file size in bytes
+  - `artifactType`: artifact type of the referrer
+  - `annotations`: arbitrary metadata attached to the referrer
+  - `referrers`: referrers of the referrer (empty array if none)
 
 See an example:
 
@@ -289,7 +296,11 @@ oras discover $REGISTRY/$REPO:v1 --format json
 
 ```json
 {
-  "manifests": [
+  "reference": "$REGISTRY/$REPO@sha256:a3785f78ab8547ae2710c89e627783cfa7ee7824d3468cae6835c9f4eae23ff7",
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "digest": "sha256:a3785f78ab8547ae2710c89e627783cfa7ee7824d3468cae6835c9f4eae23ff7",
+  "size": 528,
+  "referrers": [
     {
       "reference": "$REGISTRY/$REPO@sha256:8dee8cb9a1334595545e3baf15c3eeed13c4b35ae08e3ab32e1df31fb152dc1d",
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -299,7 +310,8 @@ oras discover $REGISTRY/$REPO:v1 --format json
         "io.cncf.notary.x509chain.thumbprint#S256": "[\"79e91aa1e109a16df87d200e493fd3d33c67253f76d41334d7f7c29c00ba55b3\"]",
         "org.opencontainers.image.created": "2024-01-01T10:32:55Z"
       },
-      "artifactType": "application/vnd.cncf.notary.signature"
+      "artifactType": "application/vnd.cncf.notary.signature",
+      "referrers": []
     },
     {
       "reference": "$REGISTRY/$REPO@sha256:50fd0dc107d84b5e7b402688000a7ed3aaf8a2692d5cb74da5277fa3c4cecf15",
@@ -309,7 +321,8 @@ oras discover $REGISTRY/$REPO:v1 --format json
       "annotations": {
         "org.opencontainers.image.created": "2024-01-01T07:57:10Z"
       },
-      "artifactType": "sbom/example"
+      "artifactType": "sbom/example",
+      "referrers": []
     }
   ]
 }


### PR DESCRIPTION
This PR updates the `oras discover --format json` documentation to accurately reflect the output format introduced in ORAS v1.3.0, which follows the OCI referrers data model.

Fixes #497
Related: #552 (supersedes — that PR missed updating the field description prose and had a digest inconsistency between examples)

## Changes

- **Updated field description prose**: The description still referenced the legacy `manifests` array. Updated to document the new structure: subject manifest fields at the root level (`reference`, `mediaType`, `digest`, `size`) and a `referrers` array containing the artifacts that reference the subject.
- **Consistent subject digest**: The tree output and JSON output examples now use the same subject digest (`sha256:a3785f78...`).
- **Updated JSON example**: Replaced the `manifests`-array format with the v1.3.0 format — subject manifest at root, `referrers` array with both notary signature and SBOM entries, each including a `referrers: []` field.
- **Updated tree example**: Added `[annotations]` display for the SBOM referrer entry, consistent with v1.3.0 tree output behavior.
- **Both referrers shown**: Kept both `application/vnd.cncf.notary.signature` and `sbom/example` referrers in both examples for a realistic multi-referrer illustration.

**If applicable**:
- [x] this PR contains user facing changes (the `docs needed` label should be applied if so)
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility