### PR TITLE
chore: Provide correct option for custom auth config

### DIFF
--- a/versioned_docs/version-1.1/how_to_guides/authentication.mdx
+++ b/versioned_docs/version-1.1/how_to_guides/authentication.mdx
@@ -13,7 +13,7 @@ This method is straightforward but insecure. It may be used for testing purposes
 
 Please note that if you have previously used `docker login`, the credentials will get reused.
 
-You may use the `-c`/`--config` option to specify an alternate location.
+You may use the `--registry-config` option to specify an alternate location.
 
 :::info
 

--- a/versioned_docs/version-1.2/how_to_guides/authentication.mdx
+++ b/versioned_docs/version-1.2/how_to_guides/authentication.mdx
@@ -13,7 +13,7 @@ This method is straightforward but insecure. It may be used for testing purposes
 
 Please note that if you have previously used `docker login`, the credentials will get reused.
 
-You may use the `-c`/`--config` option to specify an alternate location.
+You may use the `--registry-config` option to specify an alternate location.
 
 :::info
 

--- a/versioned_docs/version-1.3/how_to_guides/authentication.mdx
+++ b/versioned_docs/version-1.3/how_to_guides/authentication.mdx
@@ -13,7 +13,7 @@ This method is straightforward but insecure. It may be used for testing purposes
 
 Please note that if you have previously used `docker login`, the credentials will get reused.
 
-You may use the `-c`/`--config` option to specify an alternate location.
+You may use the `--registry-config` option to specify an alternate location.
 
 :::info
 


### PR DESCRIPTION
Previously, the `-c`/`--config` option was presented as the way to indicate to oras that a specific docker `config.json` file should be used.

As per `oras pull --help`, the correct option is actually `--registry-config`.

`--config` is used to "output manifest config file"

Example usage:
`oras pull my-registry.io/example:latest --registry-config /home/foo/config.json`

### Pull request checklist
- Does the affected code have corresponding tests, e.g. unit test, E2E test?
  - Change is to docs only
- Does this change require a documentation update?
  - Yes
- Does this introduce breaking changes that would require an announcement or bumping the major version?
  - No
- Do all new files have an appropriate license header?
  - No new files