### PR TITLE
fix: bump websocket-driver to 0.7.5 (GHSA-xv26-6w52-cph6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22789,9 +22789,9 @@
             }
         },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
## Summary

Bumps the transitive dependency `websocket-driver` from **0.7.4** to **0.7.5** to resolve **[GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6)** / **CVE-2026-54466** (Critical, CVSS 9.2, CWE-130).

The flaw lets an attacker inflate a WebSocket frame length header, causing 64-bit float precision loss and corruption of the subsequent payload. 0.7.5 rejects frames whose length header exceeds the configured max message length.

## Details

- Pulled in transitively: `@docusaurus` → `webpack-dev-server` → `sockjs`/`faye-websocket` → `websocket-driver`. Dev-server only; not shipped in the built site.
- Semver **patch** release — no API change; parents (`sockjs@^0.7.4`, `faye-websocket@>=0.5.1`) are satisfied.
- Change is limited to `package-lock.json` (single package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)