### PR TITLE
fix(docs): correct DOCR registry anchor

### DIFF
--- a/versioned_docs/version-1.3/compatible_oci_registries.mdx
+++ b/versioned_docs/version-1.3/compatible_oci_registries.mdx
@@ -24,7 +24,7 @@ We're happy to promote all usage, as well as provide feedback.*
 - [Red Hat Quay](#red-hat-quay)
 - [Artifactory](#artifactory)
 - [Harbor](#harbor)
-- [DigitalOcean Container Registry](#docr)
+- [DigitalOcean Container Registry](#digitalocean-container-registry-docr)
 
 ### CNCF Distribution
 


### PR DESCRIPTION
## Summary

Correct the DigitalOcean Container Registry table-of-contents link in the v1.3 compatible registries page.

## Root cause

Docusaurus derives the heading ID as `digitalocean-container-registry-docr`, while the link targeted the nonexistent `docr` anchor.

## Impact

Readers can now navigate from the registry list to the DOCR instructions without encountering a broken anchor.

Fixes #56

<img width="523" height="145" alt="Screenshot_2026-07-24_23-22-57" src="https://github.com/user-attachments/assets/58eed4d9-9d16-45c6-969e-c8cb8a7c93fb" />
