### PR TITLE
feat: add security.txt

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:cncf-oras-security@lists.cncf.io
+Expires: 2027-07-01T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://oras.land/.well-known/security.txt
+Policy: https://oras.land/community/reporting_security_concerns


### PR DESCRIPTION
## Summary

- Add an RFC 9116 `security.txt` file at `/.well-known/security.txt`.
- Direct vulnerability reports to the existing ORAS security contact and disclosure policy.

## Issue

Fixes #574.

## User impact

Security researchers can now discover the supported private reporting channel from a standard well-known URL.