### PR TITLE
fix(deps): override vulnerable transitive packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -308,15 +308,6 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
-        "node_modules/@antfu/utils": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-8.1.1.tgz",
-            "integrity": "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
         "node_modules/@babel/code-frame": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -341,20 +332,20 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-            "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.3",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.4",
-                "@babel/parser": "^7.28.4",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.4",
-                "@babel/types": "^7.28.4",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -666,13 +657,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2234,48 +2225,15 @@
             "license": "MIT"
         },
         "node_modules/@braintree/sanitize-url": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz",
-            "integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+            "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
             "license": "MIT"
         },
-        "node_modules/@chevrotain/cst-dts-gen": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-            "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/gast": "11.0.3",
-                "@chevrotain/types": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@chevrotain/gast": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-            "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/types": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/@chevrotain/regexp-to-ast": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-            "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
-            "license": "Apache-2.0"
-        },
         "node_modules/@chevrotain/types": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@chevrotain/utils": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+            "version": "11.1.2",
+            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+            "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
             "license": "Apache-2.0"
         },
         "node_modules/@colors/colors": {
@@ -4454,31 +4412,14 @@
             "license": "MIT"
         },
         "node_modules/@iconify/utils": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.3.0.tgz",
-            "integrity": "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+            "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
             "license": "MIT",
             "dependencies": {
-                "@antfu/install-pkg": "^1.0.0",
-                "@antfu/utils": "^8.1.0",
+                "@antfu/install-pkg": "^1.1.0",
                 "@iconify/types": "^2.0.0",
-                "debug": "^4.4.0",
-                "globals": "^15.14.0",
-                "kolorist": "^1.8.0",
-                "local-pkg": "^1.0.0",
-                "mlly": "^1.7.4"
-            }
-        },
-        "node_modules/@iconify/utils/node_modules/globals": {
-            "version": "15.15.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-            "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "import-meta-resolve": "^4.2.0"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -4577,9 +4518,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5241,12 +5182,24 @@
             }
         },
         "node_modules/@mermaid-js/parser": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.6.2.tgz",
-            "integrity": "sha512-+PO02uGF6L6Cs0Bw8RpGhikVvMWEysfAyl27qTlroUB8jSWr1lL0Sf6zi78ZxlSnmgSY2AMMKVgghnN9jTtwkQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+            "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
             "license": "MIT",
             "dependencies": {
-                "langium": "3.3.1"
+                "@chevrotain/types": "~11.1.2"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -5399,9 +5352,9 @@
             }
         },
         "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5409,10 +5362,12 @@
             }
         },
         "node_modules/@npmcli/map-workspaces/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -5429,12 +5384,13 @@
             }
         },
         "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5472,9 +5428,9 @@
             }
         },
         "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5482,10 +5438,12 @@
             }
         },
         "node_modules/@npmcli/package-json/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -5511,12 +5469,13 @@
             }
         },
         "node_modules/@npmcli/package-json/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5559,6 +5518,163 @@
             },
             "engines": {
                 "node": "^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@peculiar/asn1-cms": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+            "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-x509-attr": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-csr": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+            "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-ecc": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+            "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pfx": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+            "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.8.0",
+                "@peculiar/asn1-pkcs8": "^2.8.0",
+                "@peculiar/asn1-rsa": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs8": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+            "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs9": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+            "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.8.0",
+                "@peculiar/asn1-pfx": "^2.8.0",
+                "@peculiar/asn1-pkcs8": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-x509-attr": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-rsa": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+            "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-schema": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+            "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+            "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+            "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-x509": "^2.8.0",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/x509": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+            "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.0",
+                "@peculiar/asn1-csr": "^2.6.0",
+                "@peculiar/asn1-ecc": "^2.6.0",
+                "@peculiar/asn1-pkcs9": "^2.6.0",
+                "@peculiar/asn1-rsa": "^2.6.0",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.0",
+                "pvtsutils": "^1.3.6",
+                "reflect-metadata": "^0.2.2",
+                "tslib": "^2.8.1",
+                "tsyringe": "^4.10.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -6023,22 +6139,13 @@
             }
         },
         "node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
-            }
-        },
-        "node_modules/@trysound/sax": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=10.13.0"
             }
         },
         "node_modules/@types/acorn": {
@@ -6410,28 +6517,11 @@
                 "@types/ms": "*"
             }
         },
-        "node_modules/@types/eslint": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-            "dependencies": {
-                "@types/estree": "*",
-                "@types/json-schema": "*"
-            }
-        },
-        "node_modules/@types/eslint-scope": {
-            "version": "3.7.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-            "dependencies": {
-                "@types/eslint": "*",
-                "@types/estree": "*"
-            }
-        },
         "node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "license": "MIT"
         },
         "node_modules/@types/estree-jsx": {
             "version": "1.0.5",
@@ -6442,15 +6532,15 @@
             }
         },
         "node_modules/@types/express": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
-            "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+            "version": "4.17.25",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+            "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
             "license": "MIT",
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
                 "@types/qs": "*",
-                "@types/serve-static": "*"
+                "@types/serve-static": "^1"
             }
         },
         "node_modules/@types/express-serve-static-core": {
@@ -6602,15 +6692,6 @@
             "integrity": "sha512-bm6EG6/pCpkxDf/0gDNDdtDILMOHgaQBVOJGdwsqClnxA3xL6jtMv76rLBc006RVMWbmaf0xbmom4Z/5o2nRkQ==",
             "dependencies": {
                 "undici-types": "~6.13.0"
-            }
-        },
-        "node_modules/@types/node-forge": {
-            "version": "1.3.14",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-            "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
             }
         },
         "node_modules/@types/prismjs": {
@@ -6794,146 +6875,173 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
         },
+        "node_modules/@upsetjs/venn.js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+            "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "d3-selection": "^3.0.0",
+                "d3-transition": "^3.0.1"
+            }
+        },
         "node_modules/@webassemblyjs/ast": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-            "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+            "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+            "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+                "@webassemblyjs/helper-numbers": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
             }
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+            "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+            "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-            "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+            "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-numbers": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+            "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+            "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+                "@webassemblyjs/helper-api-error": "1.13.2",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+            "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-            "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+            "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+            "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-buffer": "1.12.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/wasm-gen": "1.12.1"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/wasm-gen": "1.14.1"
             }
         },
         "node_modules/@webassemblyjs/ieee754": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+            "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+            "license": "MIT",
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "node_modules/@webassemblyjs/leb128": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+            "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/utf8": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+            "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-            "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+            "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+            "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-buffer": "1.12.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/helper-wasm-section": "1.12.1",
-                "@webassemblyjs/wasm-gen": "1.12.1",
-                "@webassemblyjs/wasm-opt": "1.12.1",
-                "@webassemblyjs/wasm-parser": "1.12.1",
-                "@webassemblyjs/wast-printer": "1.12.1"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/helper-wasm-section": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-opt": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1",
+                "@webassemblyjs/wast-printer": "1.14.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-            "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+            "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+            "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/ieee754": "1.11.6",
-                "@webassemblyjs/leb128": "1.11.6",
-                "@webassemblyjs/utf8": "1.11.6"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
             }
         },
         "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-            "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+            "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+            "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-buffer": "1.12.1",
-                "@webassemblyjs/wasm-gen": "1.12.1",
-                "@webassemblyjs/wasm-parser": "1.12.1"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-            "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+            "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+            "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-api-error": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/ieee754": "1.11.6",
-                "@webassemblyjs/leb128": "1.11.6",
-                "@webassemblyjs/utf8": "1.11.6"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
             }
         },
         "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-            "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+            "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+            "license": "MIT",
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -6996,9 +7104,10 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -7072,9 +7181,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -7296,6 +7405,20 @@
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/astring": {
@@ -7574,23 +7697,23 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+            "version": "1.20.6",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+            "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
             "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
+                "bytes": "~3.1.2",
                 "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.13.0",
-                "raw-body": "2.5.2",
+                "destroy": "~1.2.0",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.4.24",
+                "on-finished": "~2.4.1",
+                "qs": "~6.15.1",
+                "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
+                "unpipe": "~1.0.0"
             },
             "engines": {
                 "node": ">= 0.8",
@@ -7670,9 +7793,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -7760,6 +7883,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/bytestreamjs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/cacheable-lookup": {
@@ -7999,32 +8131,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/chevrotain": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-            "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/cst-dts-gen": "11.0.3",
-                "@chevrotain/gast": "11.0.3",
-                "@chevrotain/regexp-to-ast": "11.0.3",
-                "@chevrotain/types": "11.0.3",
-                "@chevrotain/utils": "11.0.3",
-                "lodash-es": "4.17.21"
-            }
-        },
-        "node_modules/chevrotain-allstar": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-            "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-            "license": "MIT",
-            "dependencies": {
-                "lodash-es": "^4.17.21"
-            },
-            "peerDependencies": {
-                "chevrotain": "^11.0.0"
             }
         },
         "node_modules/chokidar": {
@@ -8408,12 +8514,6 @@
                 "typedarray": "^0.0.6"
             }
         },
-        "node_modules/confbox": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-            "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-            "license": "MIT"
-        },
         "node_modules/config-chain": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -8484,18 +8584,18 @@
             "license": "MIT"
         },
         "node_modules/cookie": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/cookie-signature": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+            "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
             "license": "MIT"
         },
         "node_modules/copy-text-to-clipboard": {
@@ -9152,9 +9252,9 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/cytoscape": {
-            "version": "3.32.0",
-            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.0.tgz",
-            "integrity": "sha512-5JHBC9n75kz5851jeklCPmZWcg3hUe6sjqJvyk3+hVqFaKcHwHgxsjeN1yLmggoUc6STbtm9/NQyabQehfjvWQ==",
+            "version": "3.34.0",
+            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+            "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10"
@@ -9414,9 +9514,9 @@
             }
         },
         "node_modules/d3-format": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -9650,9 +9750,9 @@
             }
         },
         "node_modules/dagre-d3-es": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.11.tgz",
-            "integrity": "sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==",
+            "version": "7.0.14",
+            "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+            "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
             "license": "MIT",
             "dependencies": {
                 "d3": "^7.9.0",
@@ -9675,9 +9775,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.13",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-            "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+            "version": "1.11.21",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+            "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
             "license": "MIT"
         },
         "node_modules/debounce": {
@@ -9858,9 +9958,9 @@
             }
         },
         "node_modules/delaunator": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-            "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+            "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
             "license": "ISC",
             "dependencies": {
                 "robust-predicates": "^3.0.2"
@@ -10051,9 +10151,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -10190,12 +10290,13 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.17.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-            "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+            "version": "5.24.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+            "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.3"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -10245,9 +10346,10 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-            "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -10276,6 +10378,17 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-toolkit": {
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks",
+                "tests/types"
+            ]
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -10593,39 +10706,39 @@
             }
         },
         "node_modules/express": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.3",
-                "content-disposition": "0.5.4",
+                "body-parser": "~1.20.5",
+                "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.7.1",
-                "cookie-signature": "1.0.6",
+                "cookie": "~0.7.1",
+                "cookie-signature": "~1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.3.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
+                "finalhandler": "~1.3.1",
+                "fresh": "~0.5.2",
+                "http-errors": "~2.0.0",
                 "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
-                "on-finished": "2.4.1",
+                "on-finished": "~2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.12",
+                "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.13.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.19.0",
-                "serve-static": "1.16.2",
+                "send": "~0.19.0",
+                "serve-static": "~1.16.2",
                 "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
+                "statuses": "~2.0.1",
                 "type-is": "~1.6.18",
                 "utils-merge": "1.0.1",
                 "vary": "~1.1.2"
@@ -10666,9 +10779,9 @@
             "license": "MIT"
         },
         "node_modules/express/node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "license": "MIT"
         },
         "node_modules/express/node_modules/range-parser": {
@@ -10679,12 +10792,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/exsolve": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.5.tgz",
-            "integrity": "sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==",
-            "license": "MIT"
         },
         "node_modules/extend": {
             "version": "3.0.2",
@@ -10728,9 +10835,9 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "funding": [
                 {
                     "type": "github",
@@ -10817,9 +10924,10 @@
             }
         },
         "node_modules/file-loader/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -10873,17 +10981,17 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+            "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
             "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
-                "on-finished": "2.4.1",
+                "on-finished": "~2.4.1",
                 "parseurl": "~1.3.3",
-                "statuses": "2.0.1",
+                "statuses": "~2.0.2",
                 "unpipe": "~1.0.0"
             },
             "engines": {
@@ -10946,9 +11054,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -10994,17 +11102,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -11016,6 +11124,29 @@
             "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
             "engines": {
                 "node": ">= 14.17"
+            }
+        },
+        "node_modules/form-data/node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/form-data/node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/format": {
@@ -11235,11 +11366,6 @@
                 "tslib": "2"
             }
         },
-        "node_modules/glob-to-regexp": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
-        },
         "node_modules/global-dirs": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
@@ -11426,9 +11552,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -11857,19 +11983,23 @@
             "license": "MIT"
         },
         "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "license": "MIT",
             "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/http-parser-js": {
@@ -11908,9 +12038,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+            "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
@@ -12167,10 +12297,10 @@
             }
         },
         "node_modules/import-meta-resolve": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-            "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
-            "dev": true,
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+            "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -13730,9 +13860,10 @@
             }
         },
         "node_modules/joi": {
-            "version": "17.13.3",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-            "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+            "version": "17.13.4",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+            "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "@hapi/hoek": "^9.3.0",
                 "@hapi/topo": "^5.1.0",
@@ -13747,9 +13878,19 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -13805,9 +13946,9 @@
             }
         },
         "node_modules/jsdom/node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13877,9 +14018,9 @@
             }
         },
         "node_modules/katex": {
-            "version": "0.16.22",
-            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
-            "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+            "version": "0.16.47",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+            "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
             "funding": [
                 "https://opencollective.com/katex",
                 "https://github.com/sponsors/katex"
@@ -13930,28 +14071,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/kolorist": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-            "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-            "license": "MIT"
-        },
-        "node_modules/langium": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-3.3.1.tgz",
-            "integrity": "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==",
-            "license": "MIT",
-            "dependencies": {
-                "chevrotain": "~11.0.3",
-                "chevrotain-allstar": "~0.3.0",
-                "vscode-languageserver": "~9.0.1",
-                "vscode-languageserver-textdocument": "~1.0.11",
-                "vscode-uri": "~3.0.8"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
         "node_modules/latest-version": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
@@ -13967,13 +14086,13 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
-            "integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+            "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.1.1",
-                "shell-quote": "^1.8.3"
+                "shell-quote": "^1.8.4"
             }
         },
         "node_modules/layout-base": {
@@ -14031,14 +14150,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/loader-runner": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-            "engines": {
-                "node": ">=6.11.5"
-            }
-        },
         "node_modules/loader-utils": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
@@ -14050,23 +14161,6 @@
             },
             "engines": {
                 "node": ">=8.9.0"
-            }
-        },
-        "node_modules/local-pkg": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
-            "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
-            "license": "MIT",
-            "dependencies": {
-                "mlly": "^1.7.4",
-                "pkg-types": "^2.0.1",
-                "quansync": "^0.2.8"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/locate-path": {
@@ -14085,14 +14179,15 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "license": "MIT"
         },
         "node_modules/lodash.debounce": {
@@ -14567,9 +14662,10 @@
             }
         },
         "node_modules/mdast-util-to-hast": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-            "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+            "version": "13.2.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+            "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/mdast": "^4.0.0",
@@ -14673,31 +14769,45 @@
             }
         },
         "node_modules/mermaid": {
-            "version": "11.10.1",
-            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.10.1.tgz",
-            "integrity": "sha512-0PdeADVWURz7VMAX0+MiMcgfxFKY4aweSGsjgFihe3XlMKNqmai/cugMrqTd3WNHM93V+K+AZL6Wu6tB5HmxRw==",
+            "version": "11.16.0",
+            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+            "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
             "license": "MIT",
             "dependencies": {
-                "@braintree/sanitize-url": "^7.0.4",
-                "@iconify/utils": "^2.1.33",
-                "@mermaid-js/parser": "^0.6.2",
+                "@braintree/sanitize-url": "^7.1.2",
+                "@iconify/utils": "^3.0.2",
+                "@mermaid-js/parser": "^1.2.0",
                 "@types/d3": "^7.4.3",
-                "cytoscape": "^3.29.3",
+                "@upsetjs/venn.js": "^2.0.0",
+                "cytoscape": "^3.33.3",
                 "cytoscape-cose-bilkent": "^4.1.0",
                 "cytoscape-fcose": "^2.2.0",
                 "d3": "^7.9.0",
                 "d3-sankey": "^0.12.3",
-                "dagre-d3-es": "7.0.11",
-                "dayjs": "^1.11.13",
-                "dompurify": "^3.2.5",
-                "katex": "^0.16.22",
+                "dagre-d3-es": "7.0.14",
+                "dayjs": "^1.11.20",
+                "dompurify": "^3.3.3",
+                "es-toolkit": "^1.45.1",
+                "katex": "^0.16.45",
                 "khroma": "^2.1.0",
-                "lodash-es": "^4.17.21",
-                "marked": "^16.0.0",
+                "marked": "^16.3.0",
                 "roughjs": "^4.6.6",
                 "stylis": "^4.3.6",
                 "ts-dedent": "^2.2.0",
-                "uuid": "^11.1.0"
+                "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+            }
+        },
+        "node_modules/mermaid/node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/methods": {
@@ -16498,6 +16608,95 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/minimizer-webpack-plugin": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+            "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^4.3.0",
+                "terser": "^5.31.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@minify-html/node": {
+                    "optional": true
+                },
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/css": {
+                    "optional": true
+                },
+                "@swc/html": {
+                    "optional": true
+                },
+                "clean-css": {
+                    "optional": true
+                },
+                "cssnano": {
+                    "optional": true
+                },
+                "csso": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "html-minifier-terser": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/minimizer-webpack-plugin/node_modules/jest-worker": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/minimizer-webpack-plugin/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/minipass": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -16505,35 +16704,6 @@
             "dev": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/mlly": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-            "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.14.0",
-                "pathe": "^2.0.1",
-                "pkg-types": "^1.3.0",
-                "ufo": "^1.5.4"
-            }
-        },
-        "node_modules/mlly/node_modules/confbox": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-            "license": "MIT"
-        },
-        "node_modules/mlly/node_modules/pkg-types": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.1.8",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.1"
             }
         },
         "node_modules/mrmime": {
@@ -16564,9 +16734,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -16629,15 +16799,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/node-forge": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
-            "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "engines": {
-                "node": ">= 6.13.0"
             }
         },
         "node_modules/node-int64": {
@@ -17134,9 +17295,9 @@
             "dev": true
         },
         "node_modules/package-manager-detector": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.3.0.tgz",
-            "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+            "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
             "license": "MIT"
         },
         "node_modules/param-case": {
@@ -17332,12 +17493,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "license": "MIT"
-        },
         "node_modules/periscopic": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
@@ -17354,9 +17509,10 @@
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -17389,15 +17545,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/pkg-types": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.0.tgz",
-            "integrity": "sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==",
-            "license": "MIT",
+        "node_modules/pkijs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
-                "confbox": "^0.2.1",
-                "exsolve": "^1.0.1",
-                "pathe": "^2.0.3"
+                "@noble/hashes": "1.4.0",
+                "asn1js": "^3.0.6",
+                "bytestreamjs": "^2.0.1",
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/points-on-curve": {
@@ -17417,9 +17579,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -17436,7 +17598,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -19110,13 +19272,32 @@
             ],
             "license": "MIT"
         },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvutils": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+            "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.0.6"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -19124,22 +19305,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/quansync": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
-            "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/antfu"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/sxzz"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/querystringify": {
             "version": "2.2.0",
@@ -19178,14 +19343,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/range-parser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -19196,15 +19353,15 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+            "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
             "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.4.24",
+                "unpipe": "~1.0.0"
             },
             "engines": {
                 "node": ">= 0.8"
@@ -19458,6 +19615,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/reflect-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+            "license": "Apache-2.0"
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -19975,9 +20138,9 @@
             }
         },
         "node_modules/robust-predicates": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+            "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
             "license": "Unlicense"
         },
         "node_modules/roughjs": {
@@ -20111,9 +20274,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/schema-utils": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-            "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "license": "MIT",
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
@@ -20155,16 +20318,16 @@
             "license": "MIT"
         },
         "node_modules/selfsigned": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+            "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
             "license": "MIT",
             "dependencies": {
-                "@types/node-forge": "^1.3.0",
-                "node-forge": "^1"
+                "@peculiar/x509": "^1.14.2",
+                "pkijs": "^3.3.3"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/semver": {
@@ -20193,24 +20356,24 @@
             }
         },
         "node_modules/send": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+            "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
             "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
+                "fresh": "~0.5.2",
+                "http-errors": "~2.0.1",
                 "mime": "1.6.0",
                 "ms": "2.1.3",
-                "on-finished": "2.4.1",
+                "on-finished": "~2.4.1",
                 "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
+                "statuses": "~2.0.2"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -20231,15 +20394,6 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
         },
-        "node_modules/send/node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/send/node_modules/range-parser": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -20250,11 +20404,12 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/serve-handler": {
@@ -20357,15 +20512,15 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+            "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
             "license": "MIT",
             "dependencies": {
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.19.0"
+                "send": "~0.19.1"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -20430,9 +20585,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -20442,14 +20597,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -20461,13 +20616,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -20602,12 +20757,16 @@
             }
         },
         "node_modules/sockjs/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/sort-css-media-queries": {
@@ -20766,9 +20925,9 @@
             }
         },
         "node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -21025,18 +21184,18 @@
             "license": "MIT"
         },
         "node_modules/svgo": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-            "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+            "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
             "license": "MIT",
             "dependencies": {
-                "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
                 "css-select": "^5.1.0",
                 "css-tree": "^2.3.1",
                 "css-what": "^6.1.0",
                 "csso": "^5.0.5",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.0.0",
+                "sax": "^1.5.0"
             },
             "bin": {
                 "svgo": "bin/svgo"
@@ -21066,11 +21225,16 @@
             "license": "MIT"
         },
         "node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/terser": {
@@ -21091,15 +21255,15 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.10",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
-            "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+            "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.20",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
-                "schema-utils": "^3.1.1",
-                "serialize-javascript": "^6.0.1",
-                "terser": "^5.26.0"
+                "schema-utils": "^4.3.0",
+                "terser": "^5.31.1"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -21112,38 +21276,42 @@
                 "webpack": "^5.1.0"
             },
             "peerDependenciesMeta": {
+                "@minify-html/node": {
+                    "optional": true
+                },
                 "@swc/core": {
+                    "optional": true
+                },
+                "@swc/css": {
+                    "optional": true
+                },
+                "@swc/html": {
+                    "optional": true
+                },
+                "clean-css": {
+                    "optional": true
+                },
+                "cssnano": {
+                    "optional": true
+                },
+                "csso": {
                     "optional": true
                 },
                 "esbuild": {
                     "optional": true
                 },
+                "html-minifier-terser": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
                 "uglify-js": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/terser-webpack-plugin/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "peerDependencies": {
-                "ajv": "^6.9.1"
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
@@ -21157,28 +21325,6 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
-            }
-        },
-        "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-            "dependencies": {
-                "@types/json-schema": "^7.0.8",
-                "ajv": "^6.12.5",
-                "ajv-keywords": "^3.5.2"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/supports-color": {
@@ -21254,10 +21400,13 @@
             "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
         },
         "node_modules/tinyexec": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-            "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
-            "license": "MIT"
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/tinypool": {
             "version": "1.1.0",
@@ -21386,9 +21535,28 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/tsyringe": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+            "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/tsyringe/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
         },
         "node_modules/type-detect": {
             "version": "4.0.8",
@@ -21458,12 +21626,6 @@
             "dependencies": {
                 "is-typedarray": "^1.0.0"
             }
-        },
-        "node_modules/ufo": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-            "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
-            "license": "MIT"
         },
         "node_modules/undici-types": {
             "version": "6.13.0",
@@ -21631,9 +21793,9 @@
             }
         },
         "node_modules/unified-engine/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -21641,10 +21803,12 @@
             }
         },
         "node_modules/unified-engine/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -21689,12 +21853,13 @@
             }
         },
         "node_modules/unified-engine/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -22001,9 +22166,10 @@
             }
         },
         "node_modules/url-loader/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -22100,19 +22266,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {
@@ -22313,55 +22466,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/vscode-jsonrpc": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/vscode-languageserver": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-            "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-languageserver-protocol": "3.17.5"
-            },
-            "bin": {
-                "installServerIntoExtension": "bin/installServerIntoExtension"
-            }
-        },
-        "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-            "license": "MIT",
-            "dependencies": {
-                "vscode-jsonrpc": "8.2.0",
-                "vscode-languageserver-types": "3.17.5"
-            }
-        },
-        "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-            "license": "MIT"
-        },
-        "node_modules/vscode-languageserver-types": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-            "license": "MIT"
-        },
-        "node_modules/vscode-uri": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-            "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-            "license": "MIT"
-        },
         "node_modules/w3c-xmlserializer": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
@@ -22392,11 +22496,11 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-            "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+            "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+            "license": "MIT",
             "dependencies": {
-                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
             },
             "engines": {
@@ -22432,33 +22536,31 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.96.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-            "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+            "version": "5.109.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.0.tgz",
+            "integrity": "sha512-vomrngskVVXEZF9sMZfYAd4pXZUnfaWdJGlF+BTNF+gJBCKYCQBnOeVPlrh39Ewl7nlCsirDplMy6o5g9xJHBg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
-                "@webassemblyjs/ast": "^1.12.1",
-                "@webassemblyjs/wasm-edit": "^1.12.1",
-                "@webassemblyjs/wasm-parser": "^1.12.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
+                "@webassemblyjs/ast": "^1.14.1",
+                "@webassemblyjs/wasm-edit": "^1.14.1",
+                "@webassemblyjs/wasm-parser": "^1.14.1",
+                "acorn": "^8.16.0",
+                "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
-                "es-module-lexer": "^1.2.1",
+                "enhanced-resolve": "^5.24.2",
+                "es-module-lexer": "^2.1.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
-                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
-                "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
-                "mime-types": "^2.1.27",
+                "mime-db": "^1.54.0",
+                "minimizer-webpack-plugin": "^5.6.1",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^3.2.0",
-                "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.10",
-                "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
+                "watchpack": "^2.5.2",
+                "webpack-sources": "^3.5.1"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -22569,14 +22671,14 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
-            "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+            "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
             "license": "MIT",
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
-                "@types/express": "^4.17.21",
+                "@types/express": "^4.17.25",
                 "@types/express-serve-static-core": "^4.17.21",
                 "@types/serve-index": "^1.9.4",
                 "@types/serve-static": "^1.15.5",
@@ -22586,17 +22688,17 @@
                 "bonjour-service": "^1.2.1",
                 "chokidar": "^3.6.0",
                 "colorette": "^2.0.10",
-                "compression": "^1.7.4",
+                "compression": "^1.8.1",
                 "connect-history-api-fallback": "^2.0.0",
-                "express": "^4.21.2",
+                "express": "^4.22.1",
                 "graceful-fs": "^4.2.6",
                 "http-proxy-middleware": "^2.0.9",
                 "ipaddr.js": "^2.1.0",
-                "launch-editor": "^2.6.1",
+                "launch-editor": "^2.14.1",
                 "open": "^10.0.3",
                 "p-retry": "^6.2.0",
                 "schema-utils": "^4.2.0",
-                "selfsigned": "^2.4.1",
+                "selfsigned": "^5.5.0",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
@@ -22656,9 +22758,9 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -22690,75 +22792,21 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+            "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/webpack/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/webpack/node_modules/ajv-keywords": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "peerDependencies": {
-                "ajv": "^6.9.1"
-            }
-        },
-        "node_modules/webpack/node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
         "node_modules/webpack/node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/webpack/node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/webpack/node_modules/schema-utils": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-            "dependencies": {
-                "@types/json-schema": "^7.0.8",
-                "ajv": "^6.12.5",
-                "ajv-keywords": "^3.5.2"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/webpackbar": {
@@ -22789,9 +22837,9 @@
             }
         },
         "node_modules/websocket-driver": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+            "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "http-parser-js": ">=0.5.1",
@@ -22990,9 +23038,10 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -23096,15 +23145,19 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
-            "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
         "remark-cli": "^12.0.1",
         "remark-validate-links": "^13.1.0"
     },
+    "overrides": {
+        "serialize-javascript": "7.0.5",
+        "uuid": "11.1.1"
+    },
     "browserslist": {
         "production": [
             ">0.5%",


### PR DESCRIPTION
## Summary

- Refresh the npm lockfile to current compatible transitive releases.
- Override `serialize-javascript` and `uuid` at their first patched releases.

## Why

`npm audit fix` could not update the remaining Docusaurus transitive dependencies. Its forced path proposed downgrading Docusaurus from 3.10.2 to 3.5.2, so this PR uses narrowly scoped npm overrides instead.

## Validation

- `npm audit` — 0 vulnerabilities
- `npm test` — 14 tests passed
- `npm ci && npm run build` — passed in a disposable Git worktree; the repository scripts require Git history for last-update metadata

Closes #562.
