### PR TITLE
docs: update ORAS 1.3 installation to v1.3.4

### DIFF
--- a/versioned_docs/version-1.3/installation.mdx
+++ b/versioned_docs/version-1.3/installation.mdx
@@ -93,7 +93,7 @@ set PATH=%USERPROFILE%\bin\;%PATH%
 If you have [Go](https://go.dev/) 1.24 or later installed, you can install ORAS CLI using `go install`:
 
 ```bash
-go install oras.land/oras/cmd/oras@v1.3.0
+go install oras.land/oras/cmd/oras@v1.3.4
 ```
 
 The `oras` binary will be installed in the directory specified by the `GOBIN` environment variable, which defaults to `$GOPATH/bin` or `$HOME/go/bin` if the `GOPATH` environment variable is not set. You may need to add this directory to your `PATH` environment variable to run `oras` from any location.
@@ -134,7 +134,7 @@ $ oras version
 Version:        1.3.4
 Go version:     go1.26.2
 OS/Arch:        linux/amd64
-Git commit:     fe425992fdfdf300a1cfb380bc4271b3e1a3d3db
+Git commit:     db9e29505c3059f2b8fde34ae8cae266c5c765e9
 Git tree state: clean
 ```
 

--- a/versioned_docs/version-1.3/installation.mdx
+++ b/versioned_docs/version-1.3/installation.mdx
@@ -30,7 +30,7 @@ For macOS and Linux type operating systems, you can determine operating system a
 ```bash
 OS="$(uname -s | tr A-Z a-z)"
 ARCH=$(uname -m | sed -e 's/x86_64/amd64/g')
-VERSION="1.3.2"
+VERSION="1.3.4"
 curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_${OS}_${ARCH}.tar.gz"
 mkdir -p oras-install/
 tar -zxf oras_${VERSION}_${OS}_${ARCH}.tar.gz -C oras-install/
@@ -44,7 +44,7 @@ rm -rf oras_${VERSION}_${OS}_${ARCH}.tar.gz oras-install/
 If you want to install ORAS on an AMD64-based Linux machine, run the following command:
 
 ```bash
-VERSION="1.3.2"
+VERSION="1.3.4"
 curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
 mkdir -p oras-install/
 tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
@@ -53,7 +53,7 @@ rm -rf oras_${VERSION}_*.tar.gz oras-install/
 ```
 :::note
 
-If you want to install ORAS on an ARM64-based Linux machine, you can download it from `https://github.com/oras-project/oras/releases/download/v1.3.2/oras_1.3.2_linux_arm64.tar.gz`.
+If you want to install ORAS on an ARM64-based Linux machine, you can download it from `https://github.com/oras-project/oras/releases/download/v1.3.4/oras_1.3.4_linux_arm64.tar.gz`.
 
 :::
 
@@ -62,7 +62,7 @@ If you want to install ORAS on an ARM64-based Linux machine, you can download it
 If you want to install ORAS on a Mac computer with Apple silicon, run the following command:
 
 ```bash
-VERSION="1.3.2"
+VERSION="1.3.4"
 curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_darwin_arm64.tar.gz"
 mkdir -p oras-install/
 tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
@@ -71,7 +71,7 @@ rm -rf oras_${VERSION}_*.tar.gz oras-install/
 ```
 :::note
 
-If you want to install ORAS on an Intel-based Mac, you can download it from `https://github.com/oras-project/oras/releases/download/v1.3.2/oras_1.3.2_darwin_amd64.tar.gz`.
+If you want to install ORAS on an Intel-based Mac, you can download it from `https://github.com/oras-project/oras/releases/download/v1.3.4/oras_1.3.4_darwin_amd64.tar.gz`.
 
 :::
 
@@ -80,7 +80,7 @@ If you want to install ORAS on an Intel-based Mac, you can download it from `htt
 You can install ORAS CLI using `.exe` installer. Add `%USERPROFILE%\bin\` to your `PATH` environment variable so that `oras.exe` can be found.
 
 ```cmd
-set VERSION="1.3.2"
+set VERSION="1.3.4"
 curl.exe -sLO  "https://github.com/oras-project/oras/releases/download/v%VERSION%/oras_%VERSION%_windows_amd64.zip"
 tar.exe -xvzf oras_%VERSION%_windows_amd64.zip
 mkdir -p %USERPROFILE%\bin\
@@ -103,7 +103,7 @@ The `oras` binary will be installed in the directory specified by the `GOBIN` en
 A public Docker image containing the CLI is available on [GitHub Container Registry](https://github.com/orgs/oras-project/packages/container/package/oras):
 
 ```
-docker run -it --rm -v $(pwd):/workspace ghcr.io/oras-project/oras:v1.3.2 help
+docker run -it --rm -v $(pwd):/workspace ghcr.io/oras-project/oras:v1.3.4 help
 ```
 :::note
 
@@ -115,7 +115,7 @@ You can use the Docker image locally instead of installing a binary.
 For example create an alias:
 
 ```
-alias doras='docker run -it --rm -v $(pwd):/workspace ghcr.io/oras-project/oras:v1.3.2'
+alias doras='docker run -it --rm -v $(pwd):/workspace ghcr.io/oras-project/oras:v1.3.4'
 ```
 
 Run ORAS commands:
@@ -131,7 +131,7 @@ Your Go version, OS/Arch and Git commit may vary depending on what you have down
 ```shell
 $ oras version
 
-Version:        1.3.2
+Version:        1.3.4
 Go version:     go1.26.2
 OS/Arch:        linux/amd64
 Git commit:     fe425992fdfdf300a1cfb380bc4271b3e1a3d3db


### PR DESCRIPTION
## Summary

- Update the ORAS 1.3 installation examples and version output to v1.3.4.
- Update the Go install example and displayed Git commit to match v1.3.4.

## Testing

- `npm run check-links`
- `remark --frail --use remark-validate-links versioned_docs/version-1.3/installation.mdx`
- `vale --config .vale.ini versioned_docs/version-1.3/installation.mdx`
- `npm test -- --runInBand`
- `docusaurus build`

Fixes #588.