### PR TITLE
build(deps): upgrade react and react-dom to 19.x

### DIFF
--- a/__mocks__/@docusaurus/Head.js
+++ b/__mocks__/@docusaurus/Head.js
@@ -1,5 +1,5 @@
 import React from 'react';
 
-const Head = ({ children }) => <head>{children}</head>;
+const Head = ({ children }) => <>{children}</>;
 
 export default Head;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
                 "@mdx-js/react": "^3.1.1",
                 "clsx": "^2.1.1",
                 "prism-react-renderer": "^2.4.1",
-                "react": "^18.3.1",
-                "react-dom": "^18.3.1",
+                "react": "^19.0.0",
+                "react-dom": "^19.0.0",
                 "react-fast-marquee": "^1.6.5",
                 "remark-parse": "^11.0.0"
             },
@@ -63,15 +63,15 @@
             "license": "MIT"
         },
         "node_modules/@algolia/abtesting": {
-            "version": "1.21.2",
-            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.2.tgz",
-            "integrity": "sha512-uXj0rgk30EpsKvOpuS+R+1XFDrnm56hED1Lz56e8uBkZdKCxw99LS2U8eXBqAHYU8kpkbsnV1GC8velBG070Hg==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.23.0.tgz",
+            "integrity": "sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -110,99 +110,99 @@
             }
         },
         "node_modules/@algolia/client-abtesting": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.2.tgz",
-            "integrity": "sha512-y7Epol8HcjlBxKXHhyhfFPFhm78B3P6x9cCbCyGTdxjsdVCptXCy5hpkZWxjGpnaLHvWsHS4QRF0TiBOLst2xg==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.57.0.tgz",
+            "integrity": "sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.2.tgz",
-            "integrity": "sha512-8Pxj2VVmpM2d+UZufnlTq7T1QIcYPVugLV5XC50PnHsV5uRM9CSoYkg2Y+CwqwRk2La0xK5QsfZ0obIU+9XftQ==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.57.0.tgz",
+            "integrity": "sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.2.tgz",
-            "integrity": "sha512-9L4IpIYUqA63a7sw1trnHQGUvwiAjKz67nsgDnal98JGAc7wyposRb0Iag+eiMuyzFFaSHLe2/rGyIo+PafRBA==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.57.0.tgz",
+            "integrity": "sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-insights": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.2.tgz",
-            "integrity": "sha512-ZBm2ytY5EHFcj+kjNsXxMNO/TGlOHe2fBFXGKHJOM1bk1rAy4o2YI+d9oV/w/jrqx44pvJMJlc8X6vKnCuDgUQ==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.57.0.tgz",
+            "integrity": "sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.2.tgz",
-            "integrity": "sha512-3FGVW/jDk7sdYwqa2NKnF/qXWcttc4bvGrwNbvqz3VoWSRv42CNvRk+3Y9QJFIUf1vY50hAuVWUoFKdyc8vaXA==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.57.0.tgz",
+            "integrity": "sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-query-suggestions": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.2.tgz",
-            "integrity": "sha512-JsG8LovDAYul5t8e533tZ3O1uZILxso5zsTtB7ONc5RJ8ACdTxAAC/jaOnsBNYb+x+STP7fzx/Iro55v5DNgoQ==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.57.0.tgz",
+            "integrity": "sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.2.tgz",
-            "integrity": "sha512-5wDnoIfC75zJ2MSHv5SSzTlRL2z7jQMbqQ5jrzottuq2p3oBObv8pD/JpXWu8pRaimaxNr3/Bs/KZIGVXxJ7hg==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.57.0.tgz",
+            "integrity": "sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -215,81 +215,81 @@
             "license": "MIT"
         },
         "node_modules/@algolia/ingestion": {
-            "version": "1.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.2.tgz",
-            "integrity": "sha512-da+SC6ikpza98W7C5ChsKEQDvZc8PQLQ0sxmQ5yMRsHpdD3iPKnclJA6ViB5Nr5T9qOX+IDswC6AyqY4V3rtug==",
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.57.0.tgz",
+            "integrity": "sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/monitoring": {
-            "version": "1.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.2.tgz",
-            "integrity": "sha512-Y8kEcPqCiIEeaGv83l9RRA09mfYECqAJHNnOyEtZc9UirI6XBMUyFVss/sSeYUiV/Lf30hkbWcl00V1uXsf86Q==",
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.57.0.tgz",
+            "integrity": "sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.2.tgz",
-            "integrity": "sha512-5zmobuCQqFZkx+84Nt+suL7vo6jTh2CfAs2ndDSeTS2QHvnzP8YEEGWtWftjyACI0cK/FuH8urWwCHP+d2j8TA==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.57.0.tgz",
+            "integrity": "sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/client-common": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.2.tgz",
-            "integrity": "sha512-qnGUUuWG66dRMnr33owLsrYIh9fHVxtU4R2rd3SpneAHuoAUcGbDOWNrj05glVU6M8yOqo9gQ22K8zpz0I8Xpg==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.57.0.tgz",
+            "integrity": "sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2"
+                "@algolia/client-common": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-fetch": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.2.tgz",
-            "integrity": "sha512-lKZ5uhafMvR7dWCJEyuaeyZitid1I3ICx+k0vGf5x/ktdIQvc7bndCiOPpmIDqUmN26FE3jTehkAzSqee95G2Q==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.57.0.tgz",
+            "integrity": "sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2"
+                "@algolia/client-common": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.2.tgz",
-            "integrity": "sha512-Zc90xvKWUvxcNicvvTO9Pr/hT2TAnkixOIzJm/KMj5Ptm2pKjk71ngTsdkbRtJQvhZ2Kr9N1YdIjLrNHB5P2xw==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.57.0.tgz",
+            "integrity": "sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.55.2"
+                "@algolia/client-common": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -2240,6 +2240,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
             "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=0.1.90"
@@ -2479,9 +2480,9 @@
             }
         },
         "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -2900,9 +2901,9 @@
             }
         },
         "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -3347,9 +3348,9 @@
             }
         },
         "node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -3565,14 +3566,15 @@
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
             "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             }
         },
         "node_modules/@docsearch/core": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
-            "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.7.0.tgz",
+            "integrity": "sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==",
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3592,20 +3594,20 @@
             }
         },
         "node_modules/@docsearch/css": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
-            "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.7.0.tgz",
+            "integrity": "sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==",
             "license": "MIT"
         },
         "node_modules/@docsearch/react": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
-            "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.7.0.tgz",
+            "integrity": "sha512-x6oedjJ8O8/pIDBsMo5Orca3/6cQCz616/CwthVe68l43mqnj2lrJ9kFQITBqy8hMsS3nWeBWFoVO5dJ1DCFKA==",
             "license": "MIT",
             "dependencies": {
                 "@algolia/autocomplete-core": "1.19.2",
-                "@docsearch/core": "4.6.3",
-                "@docsearch/css": "4.6.3"
+                "@docsearch/core": "4.7.0",
+                "@docsearch/css": "4.7.0"
             },
             "peerDependencies": {
                 "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3793,19 +3795,6 @@
                 "@docusaurus/faster": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@docusaurus/core/node_modules/webpack-merge": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-            "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-            "dependencies": {
-                "clone-deep": "^4.0.1",
-                "flat": "^5.0.2",
-                "wildcard": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@docusaurus/cssnano-preset": {
@@ -4318,6 +4307,20 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@docusaurus/types/node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "license": "MIT",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@docusaurus/utils": {
@@ -5028,9 +5031,9 @@
             }
         },
         "node_modules/@jsonjoy.com/buffers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.0.0.tgz",
-            "integrity": "sha512-NDigYR3PHqCnQLXYyoLbnEdzMMvzeiCWo1KOut7Q0CoIqg9tUAPKJ1iq/2nFhc5kZtexzutNY0LFjdwWL3Dw3Q==",
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+            "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.0"
@@ -5059,20 +5062,301 @@
                 "tslib": "2"
             }
         },
+        "node_modules/@jsonjoy.com/fs-core": {
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.2.tgz",
+            "integrity": "sha512-PoBeUNEbjyLKKwCap2z8LkkqdhdfttS4rTHCALVuP65BdF+sAoyBqHo1m+uGTRBiQWv3H7MGfr8f7lY4pDwanw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.68.2",
+                "@jsonjoy.com/fs-node-utils": "4.68.2",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-fsa": {
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.2.tgz",
+            "integrity": "sha512-h6eGXlLGGMyPfNliDQrbuHKTB9Z29ksCLjreAmdBqrDOBdfrTrHssi+b9WLfrF+J2KzAbIt9OMjJu6AEpTnYkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.2",
+                "@jsonjoy.com/fs-node-builtins": "4.68.2",
+                "@jsonjoy.com/fs-node-utils": "4.68.2",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node": {
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.2.tgz",
+            "integrity": "sha512-Kpj519Qk4OXG4+mZ8vTf9BEflliJrPueIDEVcbx8tAOufMJJ8IxR0WwdbcEvJol2KQog3PJjtALXVclorE+xbQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.2",
+                "@jsonjoy.com/fs-node-builtins": "4.68.2",
+                "@jsonjoy.com/fs-node-utils": "4.68.2",
+                "@jsonjoy.com/fs-print": "4.68.2",
+                "@jsonjoy.com/fs-snapshot": "4.68.2",
+                "glob-to-regex.js": "^1.0.0",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-builtins": {
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.2.tgz",
+            "integrity": "sha512-V8WzQsW2YIrH3RxBGY6HZisxn+dDUltHgksVRuCdPEOXEkAfXuhL/01eHFrabNu84Dn13XuLqvcQUKOYVKAUOA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.2.tgz",
+            "integrity": "sha512-4O1K4w5G4oJIpKpoa3WSLG83AsQYVnGv+aUSBGOvIUph9Axm6bB1mPlvldkNg2tBx/4dkiTlZnqNrK5SQ21Wtg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-fsa": "4.68.2",
+                "@jsonjoy.com/fs-node-builtins": "4.68.2",
+                "@jsonjoy.com/fs-node-utils": "4.68.2"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-utils": {
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.2.tgz",
+            "integrity": "sha512-CxFwyG9fJr7dAKAd1uanNRNrRMtDDqbYJA8do53+M4LY7SxcBEEmMjC1zi9MOsBlVLHTXvA7OP9+n639UqtIcw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.68.2",
+                "glob-to-regex.js": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-print": {
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.2.tgz",
+            "integrity": "sha512-cBABQmZJXig6bahwNka3+yPNGUF1GeMWbR76ZM1N2ajgCd+S+twZigCoe9+0ueZmkhM9xd2a7688Gy/ch7T+2w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-utils": "4.68.2",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot": {
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.2.tgz",
+            "integrity": "sha512-Aix7+NM38LzvewM0T3PICSgFdF5BVCtVgsjNsrlDPGc9hiMgJzReTDDl2/elgl0A9USMl3QP27x5WwxZSOtrfw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^17.65.0",
+                "@jsonjoy.com/fs-node-utils": "4.68.2",
+                "@jsonjoy.com/json-pack": "^17.65.0",
+                "@jsonjoy.com/util": "^17.65.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+            "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+            "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+            "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "17.67.0",
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0",
+                "@jsonjoy.com/json-pointer": "17.67.0",
+                "@jsonjoy.com/util": "17.67.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+            "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/util": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+            "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
         "node_modules/@jsonjoy.com/json-pack": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.14.0.tgz",
-            "integrity": "sha512-LpWbYgVnKzphN5S6uss4M25jJ/9+m6q6UJoeN6zTkK4xAGhKsiBRPVeF7OYMWonn5repMQbE5vieRXcMUrKDKw==",
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@jsonjoy.com/base64": "^1.1.2",
-                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/buffers": "^1.2.0",
                 "@jsonjoy.com/codegen": "^1.0.0",
-                "@jsonjoy.com/json-pointer": "^1.0.1",
+                "@jsonjoy.com/json-pointer": "^1.0.2",
                 "@jsonjoy.com/util": "^1.9.0",
                 "hyperdyperid": "^1.2.0",
-                "thingies": "^2.5.0"
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
             },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.0"
             },
@@ -5113,6 +5397,22 @@
                 "@jsonjoy.com/buffers": "^1.0.0",
                 "@jsonjoy.com/codegen": "^1.0.0"
             },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.0"
             },
@@ -5521,129 +5821,159 @@
             }
         },
         "node_modules/@peculiar/asn1-cms": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
-            "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.9.4.tgz",
+            "integrity": "sha512-cben7oxmQsUGZqotus7yt0srYdncOT6RNWcTQ77T2RFOXejYVYkXadrfePdRcrVpO9K95IRLKKglG2k38jKXuw==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.8.0",
-                "@peculiar/asn1-x509": "^2.8.0",
-                "@peculiar/asn1-x509-attr": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.9.4",
+                "@peculiar/asn1-x509": "^2.9.4",
+                "@peculiar/asn1-x509-attr": "^2.9.4",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-csr": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
-            "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.9.4.tgz",
+            "integrity": "sha512-xd4YN4vpRjkDAQWVfZZkeu12IEND7DOpkqaHSIHxZl1uggUNa9Ju0QxY2jHvDAS9pP0zhRBytg8ifsnGo3V0jw==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.8.0",
-                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.9.4",
+                "@peculiar/asn1-x509": "^2.9.4",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-ecc": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
-            "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.9.4.tgz",
+            "integrity": "sha512-JJXefFshRAuVAjWQo/39bkg1ywc1VaiO44S8RRC+Ykvf/u2KDmYffoDb0ZBPCR5uJy4AGKQhl8mX+Q8ShcWaXQ==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.8.0",
-                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.9.4",
+                "@peculiar/asn1-x509": "^2.9.4",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-pfx": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
-            "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.9.4.tgz",
+            "integrity": "sha512-khuGzHTzNzk4GDlIBEILyIs6Lce0yn0ZBdoI9v93kmNncfZRhD+AQ5ODFqdhvoE8cMJF/JMTQ8yA+t1D14kqCw==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-cms": "^2.8.0",
-                "@peculiar/asn1-pkcs8": "^2.8.0",
-                "@peculiar/asn1-rsa": "^2.8.0",
-                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-cms": "^2.9.4",
+                "@peculiar/asn1-pkcs8": "^2.9.4",
+                "@peculiar/asn1-rsa": "^2.9.4",
+                "@peculiar/asn1-schema": "^2.9.4",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-pkcs8": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
-            "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.9.4.tgz",
+            "integrity": "sha512-duRdotlUx9eDZe6QrQpQKl61RbWykCHBCkKayP8V8XdEFwlKHZ8qGGDMyS6Pye7OX7nLFttTTpRkJeet78ckwQ==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.8.0",
-                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.9.4",
+                "@peculiar/asn1-x509": "^2.9.4",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-pkcs9": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
-            "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.9.4.tgz",
+            "integrity": "sha512-kaL4cNxBpdQE2dKlyZBqz4ygCrwffO+8wfoxTEqM1Z8RadvCeELBRzcv0dzM8aY9azHMwODO5nxU65zXmhToOQ==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-cms": "^2.8.0",
-                "@peculiar/asn1-pfx": "^2.8.0",
-                "@peculiar/asn1-pkcs8": "^2.8.0",
-                "@peculiar/asn1-schema": "^2.8.0",
-                "@peculiar/asn1-x509": "^2.8.0",
-                "@peculiar/asn1-x509-attr": "^2.8.0",
+                "@peculiar/asn1-cms": "^2.9.4",
+                "@peculiar/asn1-pfx": "^2.9.4",
+                "@peculiar/asn1-pkcs8": "^2.9.4",
+                "@peculiar/asn1-schema": "^2.9.4",
+                "@peculiar/asn1-x509": "^2.9.4",
+                "@peculiar/asn1-x509-attr": "^2.9.4",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-rsa": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
-            "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.9.4.tgz",
+            "integrity": "sha512-pZ96eD1PptovcWQ/GSmuNFXd/7EQJNlKfDaNCyE2rx3W0v6QFelkzquVqRSRyyDXXCYD69ZXJDzZ8GhIiQzKoA==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.8.0",
-                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.9.4",
+                "@peculiar/asn1-x509": "^2.9.4",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-schema": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
-            "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.4.tgz",
+            "integrity": "sha512-GjzePcT9Iw8NzeOPf73iNS9xM+TBhd/FilAfP+RQGkTMQJTVWtytN3JHJACCjf/ABNau5S7mS3g+DcuxmRgYEg==",
             "license": "MIT",
             "dependencies": {
                 "@peculiar/utils": "^2.0.2",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-x509": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
-            "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.9.4.tgz",
+            "integrity": "sha512-CxhBo/RdEbMMob7T31ZdQjGuoyRFLVwrDzTn25bihzBasRg9kRm/0IxIPvhgQtcK/9dNcO1XQL2fuPugwELL0Q==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.9.4",
                 "@peculiar/utils": "^2.0.2",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/asn1-x509-attr": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
-            "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.9.4.tgz",
+            "integrity": "sha512-ehQXbpQaQYycgu8OrvigwSPTFfVRcu0ECNYCWw+yzBp02Lw5paRqzzhUpfOgO2K38+WfFZuEz/0RPtam5g0OMg==",
             "license": "MIT",
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.8.0",
-                "@peculiar/asn1-x509": "^2.8.0",
+                "@peculiar/asn1-schema": "^2.9.4",
+                "@peculiar/asn1-x509": "^2.9.4",
                 "asn1js": "^3.0.10",
                 "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@peculiar/utils": {
@@ -5691,6 +6021,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
             "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12.22.0"
             }
@@ -5699,6 +6030,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
             "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "4.2.10"
             },
@@ -5709,12 +6041,14 @@
         "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "license": "ISC"
         },
         "node_modules/@pnpm/npm-conf": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
-            "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+            "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+            "license": "MIT",
             "dependencies": {
                 "@pnpm/config.env-replace": "^1.1.0",
                 "@pnpm/network.ca-file": "^1.0.1",
@@ -5725,9 +6059,10 @@
             }
         },
         "node_modules/@polka/url": {
-            "version": "1.0.0-next.25",
-            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.25.tgz",
-            "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ=="
+            "version": "1.0.0-next.29",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+            "license": "MIT"
         },
         "node_modules/@sideway/address": {
             "version": "4.1.5",
@@ -5757,6 +6092,7 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
             "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -5788,6 +6124,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@slorber/remark-comment/-/remark-comment-1.0.0.tgz",
             "integrity": "sha512-RCE24n7jsOj1M0UPvIQCHTe7fI0sFL4S2nwKVWwHyVr/wI/H8GosgsJGyhnsZoGFnD/P2hLf1mSbrrgSLN93NA==",
+            "license": "MIT",
             "dependencies": {
                 "micromark-factory-space": "^1.0.0",
                 "micromark-util-character": "^1.1.0",
@@ -6055,6 +6392,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
             "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+            "license": "MIT",
             "dependencies": {
                 "defer-to-connect": "^2.0.1"
             },
@@ -6544,9 +6882,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.19.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+            "version": "4.19.9",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -6593,12 +6931,14 @@
         "node_modules/@types/html-minifier-terser": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-            "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg=="
+            "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
+            "license": "MIT"
         },
         "node_modules/@types/http-cache-semantics": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-            "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+            "license": "MIT"
         },
         "node_modules/@types/http-errors": {
             "version": "2.0.5",
@@ -6607,9 +6947,9 @@
             "license": "MIT"
         },
         "node_modules/@types/http-proxy": {
-            "version": "1.17.16",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
-            "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+            "version": "1.17.17",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+            "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -6705,9 +7045,9 @@
             "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
         },
         "node_modules/@types/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
             "license": "MIT"
         },
         "node_modules/@types/range-parser": {
@@ -6748,6 +7088,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
             "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/history": "^4.7.11",
                 "@types/react": "*",
@@ -6770,12 +7111,11 @@
             }
         },
         "node_modules/@types/send": {
-            "version": "0.17.5",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
-            "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
             "license": "MIT",
             "dependencies": {
-                "@types/mime": "^1",
                 "@types/node": "*"
             }
         },
@@ -6789,14 +7129,24 @@
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.8",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
-            "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+            "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
             "license": "MIT",
             "dependencies": {
                 "@types/http-errors": "*",
                 "@types/node": "*",
-                "@types/send": "*"
+                "@types/send": "<1"
+            }
+        },
+        "node_modules/@types/serve-static/node_modules/@types/send": {
+            "version": "0.17.6",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+            "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
             }
         },
         "node_modules/@types/sockjs": {
@@ -7226,34 +7576,34 @@
             }
         },
         "node_modules/algoliasearch": {
-            "version": "5.55.2",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.2.tgz",
-            "integrity": "sha512-OyacJsaeuLUvGWOynNqYc6sx88XvyoG39wMT8SYqL3l9wwaorDW/LPRbUPfhzw0bWsUWzNCZTnFYOrWFBKsUaw==",
+            "version": "5.57.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.57.0.tgz",
+            "integrity": "sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==",
             "license": "MIT",
             "dependencies": {
-                "@algolia/abtesting": "1.21.2",
-                "@algolia/client-abtesting": "5.55.2",
-                "@algolia/client-analytics": "5.55.2",
-                "@algolia/client-common": "5.55.2",
-                "@algolia/client-insights": "5.55.2",
-                "@algolia/client-personalization": "5.55.2",
-                "@algolia/client-query-suggestions": "5.55.2",
-                "@algolia/client-search": "5.55.2",
-                "@algolia/ingestion": "1.55.2",
-                "@algolia/monitoring": "1.55.2",
-                "@algolia/recommend": "5.55.2",
-                "@algolia/requester-browser-xhr": "5.55.2",
-                "@algolia/requester-fetch": "5.55.2",
-                "@algolia/requester-node-http": "5.55.2"
+                "@algolia/abtesting": "1.23.0",
+                "@algolia/client-abtesting": "5.57.0",
+                "@algolia/client-analytics": "5.57.0",
+                "@algolia/client-common": "5.57.0",
+                "@algolia/client-insights": "5.57.0",
+                "@algolia/client-personalization": "5.57.0",
+                "@algolia/client-query-suggestions": "5.57.0",
+                "@algolia/client-search": "5.57.0",
+                "@algolia/ingestion": "1.57.0",
+                "@algolia/monitoring": "1.57.0",
+                "@algolia/recommend": "5.57.0",
+                "@algolia/requester-browser-xhr": "5.57.0",
+                "@algolia/requester-fetch": "5.57.0",
+                "@algolia/requester-node-http": "5.57.0"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/algoliasearch-helper": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.2.tgz",
-            "integrity": "sha512-SaV+rZM3drExb0punEYYjT+sNcH74YFwN8ocjya7IDOyQvKWeQpEaSMVG3+IGTVos+feuatj7ljQ4BXlXdUp3w==",
+            "version": "3.29.3",
+            "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.3.tgz",
+            "integrity": "sha512-gVOMbbPVrCO3Xs+B+BLAIGFqIQow6qHMTYCEeBqLQB9m4ZmKUqMwkEumlal2iyyezHEd4Y0FvFTLbCRutCutIQ==",
             "license": "MIT",
             "dependencies": {
                 "@algolia/events": "^4.0.1"
@@ -7266,6 +7616,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
             "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+            "license": "ISC",
             "dependencies": {
                 "string-width": "^4.1.0"
             }
@@ -7273,12 +7624,14 @@
         "node_modules/ansi-align/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
         },
         "node_modules/ansi-align/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -7437,9 +7790,9 @@
             "license": "MIT"
         },
         "node_modules/autoprefixer": {
-            "version": "10.5.2",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
-            "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+            "version": "10.5.4",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+            "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7456,8 +7809,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.4",
-                "caniuse-lite": "^1.0.30001799",
+                "browserslist": "^4.28.6",
+                "caniuse-lite": "^1.0.30001806",
                 "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
@@ -7757,9 +8110,9 @@
             "license": "MIT"
         },
         "node_modules/bonjour-service": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
-            "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
+            "integrity": "sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -7775,6 +8128,7 @@
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-6.2.1.tgz",
             "integrity": "sha512-H4PEsJXfFI/Pt8sjDWbHlQPx4zL/bvSQjcilJmaulGt5mLDorHOHpmdXAJcBcmru7PhYSp/cDMWRko4ZUMFkSw==",
+            "license": "MIT",
             "dependencies": {
                 "ansi-align": "^3.0.1",
                 "camelcase": "^6.2.0",
@@ -7898,6 +8252,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
             "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             }
@@ -7906,6 +8261,7 @@
             "version": "10.2.14",
             "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
             "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/http-cache-semantics": "^4.0.2",
                 "get-stream": "^6.0.1",
@@ -7979,6 +8335,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
             "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+            "license": "MIT",
             "dependencies": {
                 "pascal-case": "^3.1.2",
                 "tslib": "^2.0.3"
@@ -8008,9 +8365,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001805",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-            "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8189,6 +8546,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
             "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+            "license": "MIT",
             "dependencies": {
                 "source-map": "~0.6.0"
             },
@@ -8200,6 +8558,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8217,6 +8576,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
             "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -8228,6 +8588,7 @@
             "version": "0.6.5",
             "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
             "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+            "license": "MIT",
             "dependencies": {
                 "string-width": "^4.2.0"
             },
@@ -8241,12 +8602,14 @@
         "node_modules/cli-table3/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
         },
         "node_modules/cli-table3/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -8376,9 +8739,9 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/colord": {
-            "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-            "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+            "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
             "license": "MIT"
         },
         "node_modules/colorette": {
@@ -8518,15 +8881,23 @@
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
             "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "license": "MIT",
             "dependencies": {
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
             }
         },
+        "node_modules/config-chain/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC"
+        },
         "node_modules/configstore": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
             "integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "dot-prop": "^6.0.1",
                 "graceful-fs": "^4.2.6",
@@ -8678,10 +9049,14 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.38.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.0.tgz",
-            "integrity": "sha512-XPpwqEodRljce9KswjZShh95qJ1URisBeKCjUdq27YdenkslVe7OO0ZJhlYXAChW7OhXaRLl8AAba7IBfoIHug==",
+            "version": "3.50.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+            "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
             "hasInstallScript": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -8780,6 +9155,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
             "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+            "license": "MIT",
             "dependencies": {
                 "type-fest": "^1.0.1"
             },
@@ -8794,6 +9170,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
             "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
             },
@@ -8827,9 +9204,9 @@
             }
         },
         "node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -8901,9 +9278,9 @@
             }
         },
         "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -9062,9 +9439,9 @@
             "license": "MIT"
         },
         "node_modules/cssdb": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.9.0.tgz",
-            "integrity": "sha512-J8jOU/hLjaXcO1LldOLraJSQpfLXRKof0I7mtbRyOy2AAXgqst0x9rlgi2qXeD6d0ou3ZLqcPAMqYVbpCbrxEw==",
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.11.0.tgz",
+            "integrity": "sha512-VzY/8kcK5M8oCVr/cwh24J8XVlCOITpmzCizKBC28o7Z1s23MMojXoJ3q7a+TQQoMKvxC3YlG0Z9yU10kJF1uQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9783,7 +10160,8 @@
         "node_modules/debounce": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
+            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -9825,6 +10203,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
             "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "license": "MIT",
             "dependencies": {
                 "mimic-response": "^3.1.0"
             },
@@ -9839,6 +10218,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
             "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -9865,6 +10245,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -9879,9 +10260,9 @@
             }
         },
         "node_modules/default-browser": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+            "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
             "license": "MIT",
             "dependencies": {
                 "bundle-name": "^4.1.0",
@@ -9895,9 +10276,9 @@
             }
         },
         "node_modules/default-browser-id": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -9910,6 +10291,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
             "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
@@ -10092,6 +10474,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
             "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+            "license": "MIT",
             "dependencies": {
                 "utila": "~0.4"
             }
@@ -10186,6 +10569,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
             "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+            "license": "MIT",
             "dependencies": {
                 "is-obj": "^2.0.0"
             },
@@ -10200,6 +10584,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
             "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -10221,7 +10606,8 @@
         "node_modules/duplexer": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "license": "MIT"
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
@@ -10261,7 +10647,8 @@
         "node_modules/emojilib": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
+            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+            "license": "MIT"
         },
         "node_modules/emojis-list": {
             "version": "3.0.0",
@@ -10275,6 +10662,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.1.0.tgz",
             "integrity": "sha512-VWZfnxqwNcc51hIy/sbOdEem6D+cVtpPzEEtVAFdaas30+1dgkyaOQ4sQ6Bp0tOMqWO1v+HQfYaoodOkdhK6SQ==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -10402,6 +10790,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
             "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -10571,9 +10960,9 @@
             }
         },
         "node_modules/estree-util-value-to-estree": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.4.0.tgz",
-            "integrity": "sha512-Zlp+gxis+gCfK12d3Srl2PdX2ybsEA8ZYy6vQGVQTNNYLEGRQQ56XB64bjemN8kxIKXP1nC9ip4Z+ILy9LGzvQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-3.5.0.tgz",
+            "integrity": "sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
@@ -10862,6 +11251,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
             "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+            "license": "MIT",
             "dependencies": {
                 "format": "^0.2.0"
             },
@@ -11122,6 +11512,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
             "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 14.17"
             }
@@ -11276,7 +11667,8 @@
         "node_modules/get-own-enumerable-property-symbols": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-            "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+            "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+            "license": "ISC"
         },
         "node_modules/get-package-type": {
             "version": "0.1.0",
@@ -11351,9 +11743,9 @@
             }
         },
         "node_modules/glob-to-regex.js": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.0.1.tgz",
-            "integrity": "sha512-CG/iEvgQqfzoVsMUbxSJcwbG2JwyZ3naEqPkeltwl0BSS8Bp83k3xlGms+0QdWFUAwV+uvo80wNswKF6FWEkKg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.0"
@@ -11370,6 +11762,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
             "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+            "license": "MIT",
             "dependencies": {
                 "ini": "2.0.0"
             },
@@ -11378,14 +11771,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/global-dirs/node_modules/ini": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/globby": {
@@ -11423,6 +11808,7 @@
             "version": "12.6.1",
             "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
             "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/is": "^5.2.0",
                 "@szmarczak/http-timer": "^5.0.1",
@@ -11447,6 +11833,7 @@
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
             "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -11463,6 +11850,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
             "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+            "license": "MIT",
             "dependencies": {
                 "duplexer": "^0.1.2"
             },
@@ -11544,6 +11932,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-3.0.0.tgz",
             "integrity": "sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==",
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -11564,15 +11953,16 @@
             }
         },
         "node_modules/hast-util-from-parse5": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz",
-            "integrity": "sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
                 "devlop": "^1.0.0",
-                "hastscript": "^8.0.0",
-                "property-information": "^6.0.0",
+                "hastscript": "^9.0.0",
+                "property-information": "^7.0.0",
                 "vfile": "^6.0.0",
                 "vfile-location": "^5.0.0",
                 "web-namespaces": "^2.0.0"
@@ -11582,10 +11972,21 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/hast-util-from-parse5/node_modules/property-information": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+            "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/hast-util-parse-selector": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
             "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0"
             },
@@ -11595,9 +11996,10 @@
             }
         },
         "node_modules/hast-util-raw": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.0.4.tgz",
-            "integrity": "sha512-LHE65TD2YiNsHD3YuXcKPHXPLuYh/gjp12mOfU8jxSrm1f/yJpsb0F/KKljS6U9LJoP0Ux+tCe8iJ2AsPzTdgA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
@@ -11685,14 +12087,15 @@
             }
         },
         "node_modules/hast-util-to-parse5": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
-            "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
                 "devlop": "^1.0.0",
-                "property-information": "^6.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0",
                 "web-namespaces": "^2.0.0",
                 "zwitch": "^2.0.0"
@@ -11700,6 +12103,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-to-parse5/node_modules/property-information": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+            "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/hast-util-whitespace": {
@@ -11715,14 +12128,15 @@
             }
         },
         "node_modules/hastscript": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
-            "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
                 "hast-util-parse-selector": "^4.0.0",
-                "property-information": "^6.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0"
             },
             "funding": {
@@ -11730,10 +12144,21 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/hastscript/node_modules/property-information": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+            "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "license": "MIT",
             "bin": {
                 "he": "bin/he"
             }
@@ -11877,6 +12302,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
             "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -11888,15 +12314,17 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
             "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/html-webpack-plugin": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
-            "integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
+            "version": "5.6.8",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.8.tgz",
+            "integrity": "sha512-MZmKQcTnhEh1SPSyMiEytIeDZDUoBZVorNHivQGXMASHf/BSGGOrKa2xQ5bGx3TCe1n109ecCt+cpww7wwWhKA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/html-minifier-terser": "^6.0.0",
                 "html-minifier-terser": "^6.0.2",
@@ -11912,7 +12340,7 @@
                 "url": "https://opencollective.com/html-webpack-plugin"
             },
             "peerDependencies": {
-                "@rspack/core": "0.x || 1.x",
+                "@rspack/core": "0.x || 1.x || 2.x",
                 "webpack": "^5.20.0"
             },
             "peerDependenciesMeta": {
@@ -11928,6 +12356,7 @@
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
             "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 12"
             }
@@ -11936,6 +12365,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
             "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
+            "license": "MIT",
             "dependencies": {
                 "camel-case": "^4.1.2",
                 "clean-css": "^5.2.2",
@@ -11972,9 +12402,10 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/http-deceiver": {
             "version": "1.2.7",
@@ -12077,6 +12508,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
             "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+            "license": "MIT",
             "dependencies": {
                 "quick-lru": "^5.1.1",
                 "resolve-alpn": "^1.2.0"
@@ -12193,6 +12625,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
             "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -12350,9 +12783,13 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/inline-style-parser": {
             "version": "0.1.1",
@@ -12372,14 +12809,15 @@
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.0.0"
             }
         },
         "node_modules/ipaddr.js": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
-            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+            "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
@@ -12427,6 +12865,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
             "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+            "license": "MIT",
             "dependencies": {
                 "ci-info": "^3.2.0"
             },
@@ -12570,6 +13009,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
             "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+            "license": "MIT",
             "dependencies": {
                 "global-dirs": "^3.0.0",
                 "is-path-inside": "^3.0.2"
@@ -12582,9 +13022,9 @@
             }
         },
         "node_modules/is-network-error": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
-            "integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+            "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
             "license": "MIT",
             "engines": {
                 "node": ">=16"
@@ -12594,9 +13034,10 @@
             }
         },
         "node_modules/is-npm": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.0.0.tgz",
-            "integrity": "sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
+            "integrity": "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==",
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -12616,6 +13057,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12624,6 +13066,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -12669,6 +13112,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
             "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12687,7 +13131,8 @@
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "license": "MIT"
         },
         "node_modules/is-wsl": {
             "version": "2.2.0",
@@ -12705,6 +13150,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.1.tgz",
             "integrity": "sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             }
@@ -13982,7 +14428,8 @@
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -14046,6 +14493,7 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -14075,6 +14523,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
             "integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
+            "license": "MIT",
             "dependencies": {
                 "package-json": "^8.1.0"
             },
@@ -14240,6 +14689,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
             "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -14305,9 +14755,10 @@
             }
         },
         "node_modules/markdown-table": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-            "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -14335,12 +14786,14 @@
             }
         },
         "node_modules/mdast-util-directive": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.0.0.tgz",
-            "integrity": "sha512-JUpYOqKI4mM3sZcNxmF/ox04XYFFkNwr0CFlrQIkCwbvH0xzMCqkMqAde9wRd80VAhaUrwFwKm2nxretdT1h7Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+            "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "@types/unist": "^3.0.0",
+                "ccount": "^2.0.0",
                 "devlop": "^1.0.0",
                 "mdast-util-from-markdown": "^2.0.0",
                 "mdast-util-to-markdown": "^2.0.0",
@@ -14354,9 +14807,10 @@
             }
         },
         "node_modules/mdast-util-find-and-replace": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
-            "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "escape-string-regexp": "^5.0.0",
@@ -14372,6 +14826,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
             "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -14421,6 +14876,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
             "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.0.0",
@@ -14438,6 +14894,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
             "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -14446,9 +14903,10 @@
             }
         },
         "node_modules/mdast-util-gfm": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
-            "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "license": "MIT",
             "dependencies": {
                 "mdast-util-from-markdown": "^2.0.0",
                 "mdast-util-gfm-autolink-literal": "^2.0.0",
@@ -14464,9 +14922,10 @@
             }
         },
         "node_modules/mdast-util-gfm-autolink-literal": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz",
-            "integrity": "sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "ccount": "^2.0.0",
@@ -14480,9 +14939,9 @@
             }
         },
         "node_modules/mdast-util-gfm-autolink-literal/node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -14493,15 +14952,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/mdast-util-gfm-autolink-literal/node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -14511,12 +14971,14 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/mdast-util-gfm-footnote": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
-            "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.1.0",
@@ -14533,6 +14995,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
             "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-from-markdown": "^2.0.0",
@@ -14547,6 +15010,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
             "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.0.0",
@@ -14563,6 +15027,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
             "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.0.0",
@@ -14729,11 +15194,19 @@
             }
         },
         "node_modules/memfs": {
-            "version": "4.47.0",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.47.0.tgz",
-            "integrity": "sha512-Xey8IZA57tfotV/TN4d6BmccQuhFP+CqRiI7TTNdipZdZBzF2WnzUcH//Cudw6X4zJiUbo/LTuU/HPA/iC/pNg==",
+            "version": "4.68.2",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.2.tgz",
+            "integrity": "sha512-Un1ElEBoIdPI9kg0sm3LebVEuEViodfIvlaG8Z1MFXa7ZnR9vWuPKUo3dt/vuWY2ivc05l76B5QOjdgCzAzmGw==",
             "license": "Apache-2.0",
             "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.2",
+                "@jsonjoy.com/fs-fsa": "4.68.2",
+                "@jsonjoy.com/fs-node": "4.68.2",
+                "@jsonjoy.com/fs-node-builtins": "4.68.2",
+                "@jsonjoy.com/fs-node-to-fsa": "4.68.2",
+                "@jsonjoy.com/fs-node-utils": "4.68.2",
+                "@jsonjoy.com/fs-print": "4.68.2",
+                "@jsonjoy.com/fs-snapshot": "4.68.2",
                 "@jsonjoy.com/json-pack": "^1.11.0",
                 "@jsonjoy.com/util": "^1.9.0",
                 "glob-to-regex.js": "^1.0.1",
@@ -14795,19 +15268,6 @@
                 "stylis": "^4.3.6",
                 "ts-dedent": "^2.2.0",
                 "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
-            }
-        },
-        "node_modules/mermaid/node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/methods": {
@@ -14940,9 +15400,10 @@
             ]
         },
         "node_modules/micromark-extension-directive": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.1.tgz",
-            "integrity": "sha512-VGV2uxUzhEZmaP7NSFo2vtq7M2nUD+WfmYQD+d8i/1nHbzE+rMy9uzTvUybBbNiVbrhOZibg3gbyoARGqgDWyg==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
+            "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-factory-space": "^2.0.0",
@@ -14958,9 +15419,9 @@
             }
         },
         "node_modules/micromark-extension-directive/node_modules/micromark-factory-space": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
-            "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -14971,15 +15432,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-directive/node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -14990,15 +15452,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-directive/node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15008,12 +15471,14 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-extension-frontmatter": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
             "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+            "license": "MIT",
             "dependencies": {
                 "fault": "^2.0.0",
                 "micromark-util-character": "^2.0.0",
@@ -15026,9 +15491,9 @@
             }
         },
         "node_modules/micromark-extension-frontmatter/node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15039,15 +15504,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-frontmatter/node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15057,12 +15523,14 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-extension-gfm": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
             "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "license": "MIT",
             "dependencies": {
                 "micromark-extension-gfm-autolink-literal": "^2.0.0",
                 "micromark-extension-gfm-footnote": "^2.0.0",
@@ -15082,6 +15550,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
             "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-sanitize-uri": "^2.0.0",
@@ -15094,9 +15563,9 @@
             }
         },
         "node_modules/micromark-extension-gfm-autolink-literal/node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15107,15 +15576,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-gfm-autolink-literal/node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15125,12 +15595,14 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-extension-gfm-footnote": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
             "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-core-commonmark": "^2.0.0",
@@ -15147,9 +15619,9 @@
             }
         },
         "node_modules/micromark-extension-gfm-footnote/node_modules/micromark-factory-space": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
-            "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15160,15 +15632,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-gfm-footnote/node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15179,15 +15652,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-gfm-footnote/node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15197,12 +15671,14 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-extension-gfm-strikethrough": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
             "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-util-chunked": "^2.0.0",
@@ -15217,9 +15693,9 @@
             }
         },
         "node_modules/micromark-extension-gfm-strikethrough/node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15229,12 +15705,14 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-extension-gfm-table": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz",
-            "integrity": "sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-factory-space": "^2.0.0",
@@ -15248,9 +15726,9 @@
             }
         },
         "node_modules/micromark-extension-gfm-table/node_modules/micromark-factory-space": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
-            "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15261,15 +15739,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-gfm-table/node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15280,15 +15759,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-gfm-table/node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15298,12 +15778,14 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-extension-gfm-tagfilter": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
             "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-types": "^2.0.0"
             },
@@ -15316,6 +15798,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
             "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-factory-space": "^2.0.0",
@@ -15329,9 +15812,9 @@
             }
         },
         "node_modules/micromark-extension-gfm-task-list-item/node_modules/micromark-factory-space": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
-            "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15342,15 +15825,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-gfm-task-list-item/node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15361,15 +15845,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-gfm-task-list-item/node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -15379,7 +15864,8 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-extension-mdx-expression": {
             "version": "3.0.0",
@@ -15800,6 +16286,7 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^1.0.0",
                 "micromark-util-types": "^1.0.0"
@@ -15818,7 +16305,8 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-factory-title": {
             "version": "2.0.0",
@@ -15982,6 +16470,7 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "micromark-util-symbol": "^1.0.0",
                 "micromark-util-types": "^1.0.0"
@@ -16000,7 +16489,8 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-util-chunked": {
             "version": "2.0.0",
@@ -16420,7 +16910,8 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-util-types": {
             "version": "2.0.0",
@@ -16518,6 +17009,7 @@
             "version": "1.33.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
             "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -16526,6 +17018,7 @@
             "version": "2.1.18",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "~1.33.0"
             },
@@ -16545,6 +17038,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
             "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -16707,9 +17201,10 @@
             }
         },
         "node_modules/mrmime": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-            "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
@@ -16788,9 +17283,10 @@
             }
         },
         "node_modules/node-emoji": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
-            "integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+            "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/is": "^4.6.0",
                 "char-regex": "^1.0.2",
@@ -16855,9 +17351,10 @@
             }
         },
         "node_modules/normalize-url": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-            "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+            "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -17141,6 +17638,7 @@
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
             "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+            "license": "(WTFPL OR MIT)",
             "bin": {
                 "opener": "bin/opener-bin.js"
             }
@@ -17149,6 +17647,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
             "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12.20"
             }
@@ -17275,6 +17774,7 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.1.tgz",
             "integrity": "sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==",
+            "license": "MIT",
             "dependencies": {
                 "got": "^12.1.0",
                 "registry-auth-token": "^5.0.1",
@@ -17304,6 +17804,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
             "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+            "license": "MIT",
             "dependencies": {
                 "dot-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -17366,7 +17867,8 @@
         "node_modules/parse-numeric-range": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
-            "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
+            "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+            "license": "ISC"
         },
         "node_modules/parse5": {
             "version": "7.1.2",
@@ -17405,6 +17907,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
             "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+            "license": "MIT",
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -17632,9 +18135,9 @@
             }
         },
         "node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -17876,9 +18379,9 @@
             }
         },
         "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -17914,9 +18417,9 @@
             }
         },
         "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18042,9 +18545,9 @@
             }
         },
         "node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18080,9 +18583,9 @@
             }
         },
         "node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18369,9 +18872,9 @@
             }
         },
         "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18397,9 +18900,9 @@
             }
         },
         "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18496,9 +18999,9 @@
             }
         },
         "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18859,9 +19362,9 @@
             }
         },
         "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -18952,9 +19455,9 @@
             }
         },
         "node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -19045,6 +19548,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
             "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
+            "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.20",
                 "renderkid": "^3.0.0"
@@ -19195,7 +19699,8 @@
         "node_modules/proto-list": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "license": "ISC"
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -19242,9 +19747,10 @@
             }
         },
         "node_modules/pupa": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
-            "integrity": "sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
+            "integrity": "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==",
+            "license": "MIT",
             "dependencies": {
                 "escape-goat": "^4.0.0"
             },
@@ -19282,9 +19788,9 @@
             }
         },
         "node_modules/pvutils": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-            "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+            "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.0.0"
@@ -19336,6 +19842,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
             "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -19392,6 +19899,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -19402,41 +19910,47 @@
                 "rc": "cli.js"
             }
         },
+        "node_modules/rc/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC"
+        },
         "node_modules/rc/node_modules/strip-json-comments": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+            "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+            "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+            "license": "MIT",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.2"
+                "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^18.3.1"
+                "react": "^19.2.8"
             }
         },
         "node_modules/react-fast-compare": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-            "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+            "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+            "license": "MIT"
         },
         "node_modules/react-fast-marquee": {
             "version": "1.6.5",
@@ -19448,9 +19962,11 @@
             }
         },
         "node_modules/react-helmet-async": {
+            "name": "@slorber/react-helmet-async",
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
-            "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+            "resolved": "https://registry.npmjs.org/@slorber/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+            "integrity": "sha512-e9/OK8VhwUSc67diWI8Rb3I0YgI9/SBQtnhe9aEuK6MhZm7ntZZimXgwXnd8W96YTmSOb9M4d8LwhRZyhWr/1A==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "invariant": "^2.2.4",
@@ -19459,8 +19975,8 @@
                 "shallowequal": "^1.1.0"
             },
             "peerDependencies": {
-                "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+                "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/react-is": {
@@ -19531,6 +20047,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/react-router-config/-/react-router-config-5.1.1.tgz",
             "integrity": "sha512-DuanZjaD8mQp1ppHjgnnUnyOlqYXZVjnov/JzFhjLEwd3Z4dYjMSnqrEzzGThH47vpCOqPPwJM2FtthLeJ8Pbg==",
+            "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.1.2"
             },
@@ -19658,11 +20175,12 @@
             }
         },
         "node_modules/registry-auth-token": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
-            "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+            "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+            "license": "MIT",
             "dependencies": {
-                "@pnpm/npm-conf": "^2.1.0"
+                "@pnpm/npm-conf": "^3.0.2"
             },
             "engines": {
                 "node": ">=14"
@@ -19672,6 +20190,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
             "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+            "license": "MIT",
             "dependencies": {
                 "rc": "1.2.8"
             },
@@ -19704,6 +20223,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
             "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+            "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "hast-util-raw": "^9.0.0",
@@ -19718,6 +20238,7 @@
             "version": "0.2.7",
             "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
             "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -19758,9 +20279,10 @@
             }
         },
         "node_modules/remark-directive": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.0.tgz",
-            "integrity": "sha512-l1UyWJ6Eg1VPU7Hm/9tt0zKtReJQNOA4+iDMAxTyZNWnJnFlbS/7zhiel/rogTLQ2vMYwDzSJa4BiVNqGlqIMA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
+            "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-directive": "^3.0.0",
@@ -19776,6 +20298,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-4.0.1.tgz",
             "integrity": "sha512-fHdvsTR1dHkWKev9eNyhTo4EFwbUvJ8ka9SgeWkMPYFX4WoI7ViVBms3PjlQYgw5TLvNQso3GUB/b/8t3yo+dg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.2",
                 "emoticon": "^4.0.1",
@@ -19791,6 +20314,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
             "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-frontmatter": "^2.0.0",
@@ -19803,9 +20327,10 @@
             }
         },
         "node_modules/remark-gfm": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz",
-            "integrity": "sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-gfm": "^3.0.0",
@@ -19911,6 +20436,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
             "integrity": "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==",
+            "license": "MIT",
             "dependencies": {
                 "css-select": "^4.1.3",
                 "dom-converter": "^0.2.0",
@@ -19923,6 +20449,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
             "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
                 "css-what": "^6.0.1",
@@ -19938,6 +20465,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
             "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.2.0",
@@ -19951,6 +20479,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
             "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -19965,6 +20494,7 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
             "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
@@ -19978,6 +20508,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
             "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "license": "BSD-2-Clause",
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
@@ -19993,6 +20524,7 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "domelementtype": "^2.0.1",
                 "domhandler": "^4.0.0",
@@ -20056,7 +20588,8 @@
         "node_modules/resolve-alpn": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "license": "MIT"
         },
         "node_modules/resolve-cwd": {
             "version": "3.0.0",
@@ -20109,6 +20642,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
             "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+            "license": "MIT",
             "dependencies": {
                 "lowercase-keys": "^3.0.0"
             },
@@ -20260,12 +20794,10 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.23.2",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            }
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "license": "MIT"
         },
         "node_modules/schema-dts": {
             "version": "1.1.5",
@@ -20345,6 +20877,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
             "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+            "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -20434,21 +20967,25 @@
             "license": "MIT"
         },
         "node_modules/serve-index": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-            "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
+            "integrity": "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==",
             "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.4",
+                "accepts": "~1.3.8",
                 "batch": "0.6.1",
                 "debug": "2.6.9",
                 "escape-html": "~1.0.3",
-                "http-errors": "~1.6.2",
-                "mime-types": "~2.1.17",
-                "parseurl": "~1.3.2"
+                "http-errors": "~1.8.0",
+                "mime-types": "~2.1.35",
+                "parseurl": "~1.3.3"
             },
             "engines": {
                 "node": ">= 0.8.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/serve-index/node_modules/debug": {
@@ -20470,37 +21007,47 @@
             }
         },
         "node_modules/serve-index/node_modules/http-errors": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+            "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
             "license": "MIT",
             "dependencies": {
                 "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.1"
             },
             "engines": {
                 "node": ">= 0.6"
             }
         },
-        "node_modules/serve-index/node_modules/inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-            "license": "ISC"
+        "node_modules/serve-index/node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/serve-index/node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/serve-index/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
-        },
-        "node_modules/serve-index/node_modules/setprototypeof": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-            "license": "ISC"
         },
         "node_modules/serve-index/node_modules/statuses": {
             "version": "1.5.0",
@@ -20563,7 +21110,8 @@
         "node_modules/shallowequal": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+            "license": "MIT"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -20677,6 +21225,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
             "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+            "license": "MIT",
             "dependencies": {
                 "@polka/url": "^1.0.0-next.24",
                 "mrmime": "^2.0.0",
@@ -20720,6 +21269,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
             "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+            "license": "MIT",
             "dependencies": {
                 "unicode-emoji-modifier-base": "^1.0.0"
             },
@@ -20754,19 +21304,6 @@
                 "faye-websocket": "^0.11.3",
                 "uuid": "^8.3.2",
                 "websocket-driver": "^0.7.4"
-            }
-        },
-        "node_modules/sockjs/node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/sort-css-media-queries": {
@@ -21040,6 +21577,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
             "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "get-own-enumerable-property-symbols": "^3.0.0",
                 "is-obj": "^1.0.1",
@@ -21178,10 +21716,13 @@
             }
         },
         "node_modules/svg-parser": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-            "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.1.0.tgz",
+            "integrity": "sha512-bwLf38YmY+TDYHJw1Ex0Co8c4yeXuJAo8YnXGZrscxrvYoVVIvLeniEkV1Ks/54VteMnL4FtyN1+P+TZJdUPmQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/svgo": {
             "version": "3.3.4",
@@ -21318,6 +21859,7 @@
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -21331,6 +21873,7 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -21368,9 +21911,9 @@
             "dev": true
         },
         "node_modules/thingies": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
-            "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+            "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.18"
@@ -21409,9 +21952,9 @@
             }
         },
         "node_modules/tinypool": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
-            "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
@@ -21448,6 +21991,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
             "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -21572,6 +22116,7 @@
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
             "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=12.20"
             },
@@ -21623,6 +22168,7 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "license": "MIT",
             "dependencies": {
                 "is-typedarray": "^1.0.0"
             }
@@ -21645,6 +22191,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
             "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -21903,6 +22450,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
             "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+            "license": "MIT",
             "dependencies": {
                 "crypto-random-string": "^4.0.0"
             },
@@ -22065,6 +22613,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-6.0.2.tgz",
             "integrity": "sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "boxen": "^7.0.0",
                 "chalk": "^5.0.1",
@@ -22092,6 +22641,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
             "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
+            "license": "MIT",
             "dependencies": {
                 "ansi-align": "^3.0.1",
                 "camelcase": "^7.0.1",
@@ -22113,6 +22663,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
             "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -22121,9 +22672,10 @@
             }
         },
         "node_modules/update-notifier/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -22249,7 +22801,8 @@
         "node_modules/utila": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
-            "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA=="
+            "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
+            "license": "MIT"
         },
         "node_modules/utility-types": {
             "version": "3.11.0",
@@ -22266,6 +22819,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {
@@ -22334,6 +22900,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
             "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+            "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "vfile": "^6.0.0"
@@ -22520,6 +23087,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
             "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -22582,6 +23150,7 @@
             "version": "4.10.2",
             "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
             "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
+            "license": "MIT",
             "dependencies": {
                 "@discoveryjs/json-ext": "0.5.7",
                 "acorn": "^8.0.4",
@@ -22607,6 +23176,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
             "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 10"
             }
@@ -22650,24 +23220,32 @@
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/mime-types": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "license": "MIT",
             "dependencies": {
                 "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/webpack-dev-server": {
@@ -22758,9 +23336,9 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/ws": {
-            "version": "8.21.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -22779,16 +23357,17 @@
             }
         },
         "node_modules/webpack-merge": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+            "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+            "license": "MIT",
             "dependencies": {
                 "clone-deep": "^4.0.1",
                 "flat": "^5.0.2",
-                "wildcard": "^2.0.0"
+                "wildcard": "^2.0.1"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/webpack-sources": {
@@ -22914,6 +23493,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
             "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+            "license": "MIT",
             "dependencies": {
                 "string-width": "^5.0.1"
             },
@@ -23030,6 +23610,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
             "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+            "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "is-typedarray": "^1.0.0",
@@ -23074,9 +23655,9 @@
             }
         },
         "node_modules/wsl-utils/node_modules/is-wsl": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
             "license": "MIT",
             "dependencies": {
                 "is-inside-container": "^1.0.0"
@@ -23092,6 +23673,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
             "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.4.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-fast-marquee": "^1.6.5",
         "remark-parse": "^11.0.0"
     },

--- a/src/pages/__tests__/redirects.test.jsx
+++ b/src/pages/__tests__/redirects.test.jsx
@@ -9,24 +9,24 @@ import OrasRedirect from '../oras/index.jsx';
 describe('Redirect Pages', () => {
   describe('oras-go/v2/index.jsx', () => {
     it('should render meta refresh redirect to oras-go GitHub', () => {
-      const { container } = render(<OrasGoV2Redirect />);
-      const metaRefresh = container.querySelector('meta[http-equiv="refresh"]');
+      render(<OrasGoV2Redirect />);
+      const metaRefresh = document.querySelector('meta[http-equiv="refresh"]');
 
       expect(metaRefresh).toBeInTheDocument();
       expect(metaRefresh).toHaveAttribute('content', '0; url=https://github.com/oras-project/oras-go');
     });
 
     it('should include go-import meta tag with correct content', () => {
-      const { container } = render(<OrasGoV2Redirect />);
-      const goImport = container.querySelector('meta[name="go-import"]');
+      render(<OrasGoV2Redirect />);
+      const goImport = document.querySelector('meta[name="go-import"]');
 
       expect(goImport).toBeInTheDocument();
       expect(goImport).toHaveAttribute('content', 'oras.land/oras-go/v2 git https://github.com/oras-project/oras-go');
     });
 
     it('should include go-source meta tag with correct content', () => {
-      const { container } = render(<OrasGoV2Redirect />);
-      const goSource = container.querySelector('meta[name="go-source"]');
+      render(<OrasGoV2Redirect />);
+      const goSource = document.querySelector('meta[name="go-source"]');
 
       expect(goSource).toBeInTheDocument();
       expect(goSource).toHaveAttribute(
@@ -36,8 +36,8 @@ describe('Redirect Pages', () => {
     });
 
     it('should include charset meta tag', () => {
-      const { container } = render(<OrasGoV2Redirect />);
-      const charset = container.querySelector('meta[charset="utf-8"]');
+      render(<OrasGoV2Redirect />);
+      const charset = document.querySelector('meta[charset="utf-8"]');
 
       expect(charset).toBeInTheDocument();
     });
@@ -45,24 +45,24 @@ describe('Redirect Pages', () => {
 
   describe('oras-go/index.jsx', () => {
     it('should render meta refresh redirect to oras-go GitHub', () => {
-      const { container } = render(<OrasGoRedirect />);
-      const metaRefresh = container.querySelector('meta[http-equiv="refresh"]');
+      render(<OrasGoRedirect />);
+      const metaRefresh = document.querySelector('meta[http-equiv="refresh"]');
 
       expect(metaRefresh).toBeInTheDocument();
       expect(metaRefresh).toHaveAttribute('content', '0; url=https://github.com/oras-project/oras-go');
     });
 
     it('should include go-import meta tag with correct content', () => {
-      const { container } = render(<OrasGoRedirect />);
-      const goImport = container.querySelector('meta[name="go-import"]');
+      render(<OrasGoRedirect />);
+      const goImport = document.querySelector('meta[name="go-import"]');
 
       expect(goImport).toBeInTheDocument();
       expect(goImport).toHaveAttribute('content', 'oras.land/oras-go git https://github.com/oras-project/oras-go');
     });
 
     it('should include go-source meta tag with correct content', () => {
-      const { container } = render(<OrasGoRedirect />);
-      const goSource = container.querySelector('meta[name="go-source"]');
+      render(<OrasGoRedirect />);
+      const goSource = document.querySelector('meta[name="go-source"]');
 
       expect(goSource).toBeInTheDocument();
       expect(goSource).toHaveAttribute(
@@ -72,8 +72,8 @@ describe('Redirect Pages', () => {
     });
 
     it('should include charset meta tag', () => {
-      const { container } = render(<OrasGoRedirect />);
-      const charset = container.querySelector('meta[charset="utf-8"]');
+      render(<OrasGoRedirect />);
+      const charset = document.querySelector('meta[charset="utf-8"]');
 
       expect(charset).toBeInTheDocument();
     });
@@ -81,24 +81,24 @@ describe('Redirect Pages', () => {
 
   describe('oras/index.jsx', () => {
     it('should render meta refresh redirect to oras GitHub', () => {
-      const { container } = render(<OrasRedirect />);
-      const metaRefresh = container.querySelector('meta[http-equiv="refresh"]');
+      render(<OrasRedirect />);
+      const metaRefresh = document.querySelector('meta[http-equiv="refresh"]');
 
       expect(metaRefresh).toBeInTheDocument();
       expect(metaRefresh).toHaveAttribute('content', '0; url=https://github.com/oras-project/oras');
     });
 
     it('should include go-import meta tag with correct content', () => {
-      const { container } = render(<OrasRedirect />);
-      const goImport = container.querySelector('meta[name="go-import"]');
+      render(<OrasRedirect />);
+      const goImport = document.querySelector('meta[name="go-import"]');
 
       expect(goImport).toBeInTheDocument();
       expect(goImport).toHaveAttribute('content', 'oras.land/oras git https://github.com/oras-project/oras');
     });
 
     it('should include go-source meta tag with correct content', () => {
-      const { container } = render(<OrasRedirect />);
-      const goSource = container.querySelector('meta[name="go-source"]');
+      render(<OrasRedirect />);
+      const goSource = document.querySelector('meta[name="go-source"]');
 
       expect(goSource).toBeInTheDocument();
       expect(goSource).toHaveAttribute(
@@ -108,8 +108,8 @@ describe('Redirect Pages', () => {
     });
 
     it('should not include charset meta tag (different from oras-go pages)', () => {
-      const { container } = render(<OrasRedirect />);
-      const charset = container.querySelector('meta[charset="utf-8"]');
+      render(<OrasRedirect />);
+      const charset = document.querySelector('meta[charset="utf-8"]');
 
       // This page doesn't have charset meta tag, unlike the oras-go pages
       expect(charset).not.toBeInTheDocument();
@@ -118,25 +118,33 @@ describe('Redirect Pages', () => {
 
   describe('Redirect URLs consistency', () => {
     it('should redirect oras-go/v2 and oras-go to the same URL', () => {
-      const { container: v2Container } = render(<OrasGoV2Redirect />);
-      const { container: baseContainer } = render(<OrasGoRedirect />);
+      const { unmount: unmountV2 } = render(<OrasGoV2Redirect />);
+      const v2MetaRefresh = document.querySelector('meta[http-equiv="refresh"]');
+      const v2Content = v2MetaRefresh.getAttribute('content');
+      unmountV2();
 
-      const v2MetaRefresh = v2Container.querySelector('meta[http-equiv="refresh"]');
-      const baseMetaRefresh = baseContainer.querySelector('meta[http-equiv="refresh"]');
+      const { unmount: unmountBase } = render(<OrasGoRedirect />);
+      const baseMetaRefresh = document.querySelector('meta[http-equiv="refresh"]');
+      const baseContent = baseMetaRefresh.getAttribute('content');
+      unmountBase();
 
-      expect(v2MetaRefresh.getAttribute('content')).toBe(baseMetaRefresh.getAttribute('content'));
+      expect(v2Content).toBe(baseContent);
     });
 
     it('should redirect to different repositories for oras-go and oras', () => {
-      const { container: goContainer } = render(<OrasGoRedirect />);
-      const { container: orasContainer } = render(<OrasRedirect />);
+      const { unmount: unmountGo } = render(<OrasGoRedirect />);
+      const goMetaRefresh = document.querySelector('meta[http-equiv="refresh"]');
+      const goContent = goMetaRefresh.getAttribute('content');
+      unmountGo();
 
-      const goMetaRefresh = goContainer.querySelector('meta[http-equiv="refresh"]');
-      const orasMetaRefresh = orasContainer.querySelector('meta[http-equiv="refresh"]');
+      const { unmount: unmountOras } = render(<OrasRedirect />);
+      const orasMetaRefresh = document.querySelector('meta[http-equiv="refresh"]');
+      const orasContent = orasMetaRefresh.getAttribute('content');
+      unmountOras();
 
-      expect(goMetaRefresh.getAttribute('content')).toContain('oras-go');
-      expect(orasMetaRefresh.getAttribute('content')).toContain('oras-project/oras');
-      expect(goMetaRefresh.getAttribute('content')).not.toBe(orasMetaRefresh.getAttribute('content'));
+      expect(goContent).toContain('oras-go');
+      expect(orasContent).toContain('oras-project/oras');
+      expect(goContent).not.toBe(orasContent);
     });
   });
 });


### PR DESCRIPTION
### Description
Upgrades `react` and `react-dom` from `18.3.1` to `19.x` (`^19.0.0` / `19.2.8`) to track the major React version upgrade.

- Verified `@docusaurus/core` (3.10.2) peer dependency compatibility (`react: "^18.0.0 || ^19.0.0"`).
- Updated `__mocks__/@docusaurus/Head.js` to render `<>{children}</>` Fragment to conform with React 19 document metadata handling.
- Updated `src/pages/__tests__/redirects.test.jsx` to query `document.querySelector(...)` since React 19 automatically hoists metadata tags (`<meta>`, `<title>`, etc.) to the document head.

### Related Issue
Fixes #578

### Testing
- `npm test`: All 14 unit tests pass cleanly with 0 errors and 0 warnings.
- `npm run build`: Production build completes and generates static assets successfully.
- `npm start`: Development server starts and compiles without runtime errors.