### PR TITLE
build(deps): upgrade @fortawesome/fontawesome-free to 7.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@docusaurus/theme-common": "^3.10.2",
                 "@docusaurus/theme-mermaid": "^3.10.2",
                 "@docusaurus/types": "^3.8.1",
-                "@fortawesome/fontawesome-free": "^6.7.2",
+                "@fortawesome/fontawesome-free": "^7.3.1",
                 "@mdx-js/react": "^3.1.1",
                 "clsx": "^2.1.1",
                 "prism-react-renderer": "^2.4.1",
@@ -4388,9 +4388,10 @@
             }
         },
         "node_modules/@fortawesome/fontawesome-free": {
-            "version": "6.7.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
-            "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.1.tgz",
+            "integrity": "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==",
+            "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
             "engines": {
                 "node": ">=6"
             }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@docusaurus/theme-common": "^3.10.2",
         "@docusaurus/theme-mermaid": "^3.10.2",
         "@docusaurus/types": "^3.8.1",
-        "@fortawesome/fontawesome-free": "^6.7.2",
+        "@fortawesome/fontawesome-free": "^7.3.1",
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.4.1",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -148,3 +148,7 @@ html[data-theme='dark'] .navbar__github, .navbar__twitter, .navbar__slack {
 .navbar__github:hover, .navbar__twitter:hover, .navbar__slack:hover {
   background: var(--ifm-color-primary);
 }
+
+/* Explicit font-family mappings for Font Awesome 7 to ensure webfonts and @font-face rules are retained */
+.fab, .fa-brands { font-family: "Font Awesome 7 Brands"; }
+.fas, .fa-solid, .far, .fa-regular { font-family: "Font Awesome 7 Free"; }


### PR DESCRIPTION
### Description
Upgrades `@fortawesome/fontawesome-free` from `6.7.2` to `7.x` (`^7.3.1`) to track the major version upgrade.

- Verified that navbar brand icons (`fa-slack`, `fa-github`, `fa-x-twitter`) and classes (`.fab`, `.fa-sm`) remain supported in Font Awesome 7.
- Kept `docusaurus.config.js` unchanged as a pure dependency upgrade.

### Related Issue
Fixes #581
