### PR TITLE
docs: add .NET client library page for v1.3

### DIFF
--- a/versioned_docs/version-1.3/client_libraries/dotnet.mdx
+++ b/versioned_docs/version-1.3/client_libraries/dotnet.mdx
@@ -1,0 +1,26 @@
+---
+title: .NET
+sidebar_position: 5
+---
+
+# .NET
+
+:::note
+
+🚧 .NET client library currently in progress! Contributions welcome!
+:::
+
+### NuGet
+
+- [OrasProject.Oras](https://www.nuget.org/packages/OrasProject.Oras)
+
+### Repository
+
+- [oras-dotnet](https://github.com/oras-project/oras-dotnet)
+
+**The API documentation is available at [oras-dotnet](https://oras-project.github.io/oras-dotnet/api/).**
+
+## Quick Start
+
+### Code examples
+See the [code examples](https://oras-project.github.io/oras-dotnet/api/index.html#examples).

--- a/versioned_docs/version-1.3/client_libraries/overview.mdx
+++ b/versioned_docs/version-1.3/client_libraries/overview.mdx
@@ -12,7 +12,7 @@ The following languages are currently supported:
 - [Go](./go.mdx)
 - [Python](https://oras-project.github.io/oras-py/getting_started/user-guide.html) 
 - [Rust](./rust.mdx) (in progress)
-- [C#](https://oras-project.github.io/oras-dotnet/api) (in progress)
+- [.NET](./dotnet.mdx) (in progress)
 - [Java](./java.mdx) (in progress)
 
 See the [SDK Feature Checklist](#feature-checklist) below for current feature support across languages.


### PR DESCRIPTION
Fixes #591

## Patch summary

- Add versioned_docs/version-1.3/client_libraries/dotnet.mdx for the ORAS .NET SDK.
- Update overview.mdx so C# bullet points at local .NET page.
- Scope limited to version 1.3 only; Feature Checklist left unchanged.

## Test plan

- [x] Claimed issue #591
- [x] Confirmed dotnet.mdx content matches the requested page
- [x] Confirmed overview languages bullet points to ./dotnet.mdx
- [x] Confirmed Feature Checklist columns were not modified
- [x] vale on changed files clean
- [x] Commit signed with DCO
- [ ] CI checks pass